### PR TITLE
Add BINARY curves export streaming the full solution vector

### DIFF
--- a/dynawo/sources/API/CRV/CMakeLists.txt
+++ b/dynawo/sources/API/CRV/CMakeLists.txt
@@ -30,6 +30,7 @@ set(API_CRV_SOURCES
   CRVXmlImporter.cpp
   CRVXmlExporter.cpp
   CRVCsvExporter.cpp
+  CRVBinaryCurves.cpp
   )
 
 set(API_CRV_INCLUDE_HEADERS
@@ -44,6 +45,7 @@ set(API_CRV_INCLUDE_HEADERS
   CRVExporter.h
   CRVXmlExporter.h
   CRVCsvExporter.h
+  CRVBinaryCurves.h
   )
 
 add_library(dynawo_API_CRV SHARED ${API_CRV_SOURCES})

--- a/dynawo/sources/API/CRV/CRVBinaryCurves.cpp
+++ b/dynawo/sources/API/CRV/CRVBinaryCurves.cpp
@@ -1,0 +1,154 @@
+//
+// Copyright (c) 2015-2019, RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+//
+// This file is part of Dynawo, an hybrid C++/Modelica open source time domain
+// simulation tool for power systems.
+//
+
+/**
+ * @file  CRVBinaryCurves.cpp
+ *
+ * @brief Streaming binary writer for the full solution vector
+ */
+#include "CRVBinaryCurves.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+
+#include "DYNCommon.h"
+
+namespace curves {
+
+namespace {
+
+#if defined(_WIN32) || (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+constexpr bool kHostIsLittleEndian = true;
+#else
+constexpr bool kHostIsLittleEndian = false;
+#endif
+
+// Pick an I/O buffer size for the ofstream. The default filebuf is ~8 KB
+// and an os.write() that exceeds the buffer is still copied through it
+// (libstdc++/libc++), so for large rows we must hand the stream a buffer
+// at least one row wide; small rows just want enough headroom to coalesce
+// many writes into one syscall.
+std::size_t pickStreamBufSize(std::size_t nVars) {
+  const std::size_t rowBytes = (1u + nVars) * sizeof(double);
+  constexpr std::size_t kMin = 64u * 1024u;         // 64 KiB floor
+  constexpr std::size_t kMax = 8u * 1024u * 1024u;  // 8 MiB cap
+  const std::size_t want = rowBytes * 16u;          // ~16 rows per syscall
+  return std::min(kMax, std::max(kMin, want));
+}
+
+void write_u32_le(std::ostream& os, uint32_t v) {
+  const unsigned char buf[4] = {
+      static_cast<unsigned char>(v & 0xFFu),
+      static_cast<unsigned char>((v >> 8) & 0xFFu),
+      static_cast<unsigned char>((v >> 16) & 0xFFu),
+      static_cast<unsigned char>((v >> 24) & 0xFFu),
+  };
+  os.write(reinterpret_cast<const char*>(buf), 4);
+}
+
+void encode_f64_le(char* out, double v) {
+  static_assert(sizeof(double) == 8, "double must be 8 bytes");
+  uint64_t bits;
+  std::memcpy(&bits, &v, 8);
+  for (int i = 0; i < 8; ++i)
+    out[i] = static_cast<char>((bits >> (8 * i)) & 0xFFu);
+}
+
+// Round @p v through DYN::double2String so the encoded value has the same
+// decimal precision as the CSV/XML exporters (fixed decimals below 1e6,
+// scientific notation above).
+double roundToCsvPrecision(double v) {
+  return std::stod(DYN::double2String(v));
+}
+
+}  // namespace
+
+BinaryCurves::BinaryCurves(const std::string& filename,
+                           const std::vector<std::string>& names,
+                           Precision precision)
+  : stream_buf_(pickStreamBufSize(names.size())),
+    stream_(),
+    nVars_(names.size()),
+    buf_((1 + names.size()) * sizeof(double)),
+    precision_(precision) {
+  // pubsetbuf only takes effect before the file is opened.
+  stream_.rdbuf()->pubsetbuf(stream_buf_.data(), static_cast<std::streamsize>(stream_buf_.size()));
+  stream_.open(filename, std::ios::binary);
+  if (!stream_)
+    throw std::runtime_error("BinaryCurves: cannot open '" + filename + "' for writing");
+  writeHeader(names);
+}
+
+BinaryCurves::~BinaryCurves() {
+  // Destructors must not throw; swallow any flush error.
+  try {
+    if (stream_.is_open())
+      stream_.flush();
+  } catch (...) {
+    // Intentionally ignored.
+  }
+}
+
+void BinaryCurves::record(double t, const std::vector<double>& y) {
+  if (y.size() < nVars_)
+    throw std::out_of_range("BinaryCurves::record: y vector smaller than registered variables");
+
+  if (precision_ == Precision::CSV_ROUNDED) {
+    const double rt = roundToCsvPrecision(t);
+    if (kHostIsLittleEndian) {
+      // On little-endian hosts the on-disk layout is byte-identical to the
+      // in-memory double, so memcpy the rounded doubles straight into the row
+      // buffer and skip the shift/mask encode entirely.
+      std::memcpy(buf_.data(), &rt, sizeof(double));
+      for (std::size_t i = 0; i < nVars_; ++i) {
+        const double v = roundToCsvPrecision(y[i]);
+        std::memcpy(buf_.data() + (1 + i) * sizeof(double), &v, sizeof(double));
+      }
+    } else {
+      encode_f64_le(buf_.data(), rt);
+      for (std::size_t i = 0; i < nVars_; ++i)
+        encode_f64_le(buf_.data() + (1 + i) * sizeof(double), roundToCsvPrecision(y[i]));
+    }
+  } else {  // Precision::FULL: store raw IEEE-754 bits, no rounding.
+    if (kHostIsLittleEndian) {
+      std::memcpy(buf_.data(), &t, sizeof(double));
+      std::memcpy(buf_.data() + sizeof(double), y.data(), nVars_ * sizeof(double));
+    } else {
+      encode_f64_le(buf_.data(), t);
+      for (std::size_t i = 0; i < nVars_; ++i)
+        encode_f64_le(buf_.data() + (1 + i) * sizeof(double), y[i]);
+    }
+  }
+  stream_.write(buf_.data(), static_cast<std::streamsize>(buf_.size()));
+}
+
+void BinaryCurves::close() {
+  if (stream_.is_open()) {
+    stream_.flush();
+    stream_.close();
+  }
+}
+
+void BinaryCurves::writeHeader(const std::vector<std::string>& names) {
+  stream_.write("DYNB", 4);
+  write_u32_le(stream_, 1u);
+  write_u32_le(stream_, static_cast<uint32_t>(names.size()));
+  for (const auto& name : names) {
+    write_u32_le(stream_, static_cast<uint32_t>(name.size()));
+    stream_.write(name.data(), static_cast<std::streamsize>(name.size()));
+  }
+}
+
+}  // namespace curves

--- a/dynawo/sources/API/CRV/CRVBinaryCurves.h
+++ b/dynawo/sources/API/CRV/CRVBinaryCurves.h
@@ -1,0 +1,111 @@
+//
+// Copyright (c) 2015-2019, RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+//
+// This file is part of Dynawo, an hybrid C++/Modelica open source time domain
+// simulation tool for power systems.
+//
+
+/**
+ * @file  CRVBinaryCurves.h
+ *
+ * @brief Streaming binary writer for the full solution vector
+ *
+ * File layout (all integers little-endian):
+ *
+ *   Header:
+ *     magic    : u8[4]  = {'M','O','D','C'}
+ *     version  : u32    = 1
+ *     n_vars   : u32    (number of tracked variables, NOT counting time)
+ *     for i in [0, n_vars):
+ *       name_len : u32
+ *       name     : u8[name_len]  (UTF-8, no null terminator)
+ *
+ *   Records (one per record() call):
+ *     time   : f64
+ *     values : f64[n_vars]
+ */
+#ifndef API_CRV_CRVBINARYCURVES_H_
+#define API_CRV_CRVBINARYCURVES_H_
+
+#include <cstddef>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace curves {
+
+/**
+ * @brief Precision policy for recorded values.
+ *
+ * CSV_ROUNDED rounds each value to the textual precision used by the CSV/XML
+ * exporters (via DYN::double2String), so the binary file matches those
+ * exports byte-for-byte numerically. FULL skips the rounding entirely and
+ * stores the raw 64-bit IEEE-754 doubles — losslessly and far faster, at
+ * the cost of byte-level parity with CSV/XML output.
+ */
+enum class Precision {
+  CSV_ROUNDED,
+  FULL
+};
+
+/**
+ * @brief Streams the full solution vector to a compact binary file.
+ *
+ * The output file is opened and the header flushed at construction time; each
+ * call to record() appends one time-stamped row. The stream is closed either
+ * explicitly via close() or automatically by the destructor.
+ */
+class BinaryCurves {
+ public:
+  /**
+   * @brief Open @p filename for writing and emit the header.
+   * @param filename  Output file path.
+   * @param names     Variable names in y[] order (size = number of variables).
+   * @param precision Whether to round values to CSV/XML decimal precision
+   *                  before writing, or store the raw IEEE-754 bits.
+   * @throws std::runtime_error if the file cannot be opened.
+   */
+  BinaryCurves(const std::string& filename,
+               const std::vector<std::string>& names,
+               Precision precision = Precision::CSV_ROUNDED);
+
+  ~BinaryCurves();
+
+  BinaryCurves(const BinaryCurves&) = delete;
+  BinaryCurves& operator=(const BinaryCurves&) = delete;
+
+  /**
+   * @brief Append one record (time + full y vector) to the stream.
+   * @param t Current simulation time.
+   * @param y Solution vector; must hold at least n_vars entries.
+   * @throws std::out_of_range if y.size() < n_vars.
+   */
+  void record(double t, const std::vector<double>& y);
+
+  /**
+   * @brief Flush and close the stream. No-op if already closed.
+   */
+  void close();
+
+ private:
+  void writeHeader(const std::vector<std::string>& names);
+
+  // stream_buf_ MUST be declared before stream_ so it is destroyed last:
+  // ~ofstream flushes through this buffer, and using freed memory there
+  // silently produces an empty file.
+  std::vector<char> stream_buf_;
+  std::ofstream stream_;
+  std::size_t nVars_;
+  std::vector<char> buf_;
+  Precision precision_;
+};
+
+}  // namespace curves
+
+#endif  // API_CRV_CRVBINARYCURVES_H_

--- a/dynawo/sources/API/CRV/CRVXmlHandler.cpp
+++ b/dynawo/sources/API/CRV/CRVXmlHandler.cpp
@@ -71,8 +71,15 @@ CurveHandler::~CurveHandler() {}
 
 void CurveHandler::create(attributes_type const & attributes) {
   curveRead_ = CurveFactory::newCurve();
-  curveRead_->setModelName(attributes["model"]);
-  curveRead_->setVariable(attributes["variable"]);
+  // Both model and variable are optional in the schema: a curve may declare
+  // only one to request expansion against the model (model-only = all
+  // variables of that submodel; variable-only = that variable across every
+  // submodel that exposes it). The expansion is handled downstream in
+  // ModelMulti::expandCurvesCollection.
+  if (attributes.has("model"))
+    curveRead_->setModelName(attributes["model"]);
+  if (attributes.has("variable"))
+    curveRead_->setVariable(attributes["variable"]);
   if (attributes.has("factor"))
     curveRead_->setFactor(attributes["factor"]);
 }

--- a/dynawo/sources/API/CRV/test/CMakeLists.txt
+++ b/dynawo/sources/API/CRV/test/CMakeLists.txt
@@ -17,6 +17,7 @@ set(MODULE_SOURCES
   TestCurvesCollection.cpp
   TestXmlImporter.cpp
   TestExporters.cpp
+  TestBinaryCurves.cpp
 )
 
 add_executable(${MODULE_NAME} ${MODULE_SOURCES})

--- a/dynawo/sources/API/CRV/test/TestBinaryCurves.cpp
+++ b/dynawo/sources/API/CRV/test/TestBinaryCurves.cpp
@@ -1,0 +1,406 @@
+//
+// Copyright (c) 2015-2019, RTE (http://www.rte-france.com)
+// See AUTHORS.txt
+// All rights reserved.
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at http://mozilla.org/MPL/2.0/.
+// SPDX-License-Identifier: MPL-2.0
+//
+// This file is part of Dynawo, an hybrid C++/Modelica open source time domain
+// simulation tool for power systems.
+//
+
+/**
+ * @file API/CRV/test/TestBinaryCurves.cpp
+ * @brief Unit tests for the BinaryCurves streaming writer
+ */
+
+#include "gtest_dynawo.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "CRVBinaryCurves.h"
+#include "DYNCommon.h"
+
+namespace curves {
+
+namespace {
+
+// Mirrors the anonymous-namespace helper inside CRVBinaryCurves.cpp so tests
+// can compute the exact value the writer stores after CSV-precision rounding.
+double expectedRounded(double v) {
+  return std::stod(DYN::double2String(v));
+}
+
+std::vector<unsigned char> readFile(const std::string& path) {
+  std::ifstream in(path, std::ios::binary);
+  std::ostringstream oss;
+  oss << in.rdbuf();
+  const std::string s = oss.str();
+  return std::vector<unsigned char>(s.begin(), s.end());
+}
+
+uint32_t readU32LE(const unsigned char* p) {
+  return static_cast<uint32_t>(p[0]) |
+         (static_cast<uint32_t>(p[1]) << 8) |
+         (static_cast<uint32_t>(p[2]) << 16) |
+         (static_cast<uint32_t>(p[3]) << 24);
+}
+
+double readF64LE(const unsigned char* p) {
+  uint64_t bits = 0;
+  for (int i = 0; i < 8; ++i)
+    bits |= static_cast<uint64_t>(p[i]) << (8 * i);
+  double v;
+  std::memcpy(&v, &bits, sizeof(double));
+  return v;
+}
+
+// Walks a file buffer and decodes header + records. Returns the offset
+// immediately after the header; fills @p nVars and @p namesOut.
+std::size_t parseHeader(const std::vector<unsigned char>& buf,
+                        uint32_t* nVarsOut,
+                        std::vector<std::string>* namesOut) {
+  EXPECT_GE(buf.size(), 12u);
+  EXPECT_EQ(buf[0], 'D');
+  EXPECT_EQ(buf[1], 'Y');
+  EXPECT_EQ(buf[2], 'N');
+  EXPECT_EQ(buf[3], 'B');
+  EXPECT_EQ(readU32LE(&buf[4]), 1u);
+  const uint32_t n = readU32LE(&buf[8]);
+  *nVarsOut = n;
+  std::size_t off = 12;
+  for (uint32_t i = 0; i < n; ++i) {
+    EXPECT_LE(off + 4, buf.size());
+    const uint32_t len = readU32LE(&buf[off]);
+    off += 4;
+    EXPECT_LE(off + len, buf.size());
+    namesOut->emplace_back(reinterpret_cast<const char*>(&buf[off]), len);
+    off += len;
+  }
+  return off;
+}
+
+}  // namespace
+
+//-----------------------------------------------------
+// Header is emitted on construction with the documented layout.
+//-----------------------------------------------------
+TEST(APICRVTest, BinaryCurvesHeaderOnly) {
+  const std::string path = "TestBinaryCurves_headerOnly.bin";
+  std::vector<std::string> names = {"alpha", "beta", "gamma_long_name"};
+  { BinaryCurves bc(path, names); }  // destructor flushes and closes
+
+  const auto buf = readFile(path);
+  uint32_t n = 0;
+  std::vector<std::string> got;
+  const std::size_t off = parseHeader(buf, &n, &got);
+
+  ASSERT_EQ(n, names.size());
+  ASSERT_EQ(got, names);
+  ASSERT_EQ(off, buf.size());  // no records yet
+  std::remove(path.c_str());
+}
+
+//-----------------------------------------------------
+// Zero variables: header is well-formed, records contain time only.
+//-----------------------------------------------------
+TEST(APICRVTest, BinaryCurvesEmptyVarList) {
+  const std::string path = "TestBinaryCurves_empty.bin";
+  std::vector<std::string> names;
+  {
+    BinaryCurves bc(path, names);
+    bc.record(0.5, std::vector<double>());
+    bc.record(1.5, std::vector<double>());
+  }
+
+  const auto buf = readFile(path);
+  uint32_t n = 0;
+  std::vector<std::string> got;
+  std::size_t off = parseHeader(buf, &n, &got);
+  ASSERT_EQ(n, 0u);
+  ASSERT_TRUE(got.empty());
+  ASSERT_EQ(buf.size() - off, 2u * sizeof(double));
+  ASSERT_DOUBLE_EQ(readF64LE(&buf[off]), expectedRounded(0.5));
+  ASSERT_DOUBLE_EQ(readF64LE(&buf[off + 8]), expectedRounded(1.5));
+  std::remove(path.c_str());
+}
+
+//-----------------------------------------------------
+// Each record() appends time + n_vars little-endian doubles in order.
+//-----------------------------------------------------
+TEST(APICRVTest, BinaryCurvesRecordLayout) {
+  const std::string path = "TestBinaryCurves_records.bin";
+  std::vector<std::string> names = {"v0", "v1", "v2"};
+  const std::vector<std::vector<double>> rows = {
+      {1.0,  2.0,  3.0},
+      {0.0, -1.5,  4.25},
+      {1234.5, -9.875, 1e-3},
+  };
+  const std::vector<double> times = {0.0, 0.1, 0.25};
+
+  {
+    BinaryCurves bc(path, names);
+    for (std::size_t i = 0; i < rows.size(); ++i)
+      bc.record(times[i], rows[i]);
+  }
+
+  const auto buf = readFile(path);
+  uint32_t n = 0;
+  std::vector<std::string> got;
+  std::size_t off = parseHeader(buf, &n, &got);
+  ASSERT_EQ(n, names.size());
+
+  const std::size_t rowBytes = (1 + names.size()) * sizeof(double);
+  ASSERT_EQ(buf.size() - off, rows.size() * rowBytes);
+
+  for (std::size_t r = 0; r < rows.size(); ++r) {
+    ASSERT_DOUBLE_EQ(readF64LE(&buf[off]), expectedRounded(times[r]));
+    for (std::size_t i = 0; i < names.size(); ++i)
+      ASSERT_DOUBLE_EQ(readF64LE(&buf[off + (1 + i) * sizeof(double)]),
+                       expectedRounded(rows[r][i]));
+    off += rowBytes;
+  }
+  std::remove(path.c_str());
+}
+
+//-----------------------------------------------------
+// y vectors larger than n_vars are tolerated; only the first n_vars are
+// written so the row stride stays constant.
+//-----------------------------------------------------
+TEST(APICRVTest, BinaryCurvesAcceptsLargerYVector) {
+  const std::string path = "TestBinaryCurves_largerY.bin";
+  std::vector<std::string> names = {"a", "b"};
+  std::vector<double> y = {10.0, 20.0, 99.0, -1.0};
+  {
+    BinaryCurves bc(path, names);
+    bc.record(0.0, y);
+  }
+  const auto buf = readFile(path);
+  uint32_t n = 0;
+  std::vector<std::string> got;
+  const std::size_t off = parseHeader(buf, &n, &got);
+  ASSERT_EQ(buf.size() - off, 3u * sizeof(double));  // time + 2 vars only
+  ASSERT_DOUBLE_EQ(readF64LE(&buf[off + 1 * sizeof(double)]), expectedRounded(10.0));
+  ASSERT_DOUBLE_EQ(readF64LE(&buf[off + 2 * sizeof(double)]), expectedRounded(20.0));
+  std::remove(path.c_str());
+}
+
+//-----------------------------------------------------
+// y smaller than n_vars throws.
+//-----------------------------------------------------
+TEST(APICRVTest, BinaryCurvesRejectsSmallerYVector) {
+  const std::string path = "TestBinaryCurves_smallY.bin";
+  std::vector<std::string> names = {"a", "b", "c"};
+  BinaryCurves bc(path, names);
+  std::vector<double> y = {1.0, 2.0};
+  ASSERT_THROW(bc.record(0.0, y), std::out_of_range);
+  std::remove(path.c_str());
+}
+
+//-----------------------------------------------------
+// Opening an unwritable path raises runtime_error.
+//-----------------------------------------------------
+TEST(APICRVTest, BinaryCurvesUnwritablePath) {
+  std::vector<std::string> names = {"a"};
+  // A path under a non-existent directory cannot be created by ofstream.
+  ASSERT_THROW(BinaryCurves("/no/such/dir/binary.bin", names), std::runtime_error);
+}
+
+//-----------------------------------------------------
+// close() is idempotent and the file is flushed once closed.
+//-----------------------------------------------------
+TEST(APICRVTest, BinaryCurvesCloseIsIdempotent) {
+  const std::string path = "TestBinaryCurves_close.bin";
+  std::vector<std::string> names = {"x"};
+  BinaryCurves bc(path, names);
+  bc.record(0.0, std::vector<double>{1.0});
+  bc.close();
+  bc.close();  // must not throw or crash
+
+  const auto buf = readFile(path);
+  uint32_t n = 0;
+  std::vector<std::string> got;
+  const std::size_t off = parseHeader(buf, &n, &got);
+  ASSERT_EQ(buf.size() - off, 2u * sizeof(double));
+  std::remove(path.c_str());
+}
+
+//-----------------------------------------------------
+// CSV-precision rounding: a value with more decimals than the exporter
+// precision is stored rounded (matches CSV/XML formatting).
+//-----------------------------------------------------
+TEST(APICRVTest, BinaryCurvesAppliesCsvRounding) {
+  const std::string path = "TestBinaryCurves_round.bin";
+  std::vector<std::string> names = {"x"};
+  const double raw = 1234.123456789;
+  {
+    BinaryCurves bc(path, names);
+    bc.record(0.0, std::vector<double>{raw});
+  }
+  const auto buf = readFile(path);
+  uint32_t n = 0;
+  std::vector<std::string> got;
+  const std::size_t off = parseHeader(buf, &n, &got);
+  const double stored = readF64LE(&buf[off + sizeof(double)]);
+  ASSERT_DOUBLE_EQ(stored, expectedRounded(raw));
+  // Sanity: the rounding must actually change the value here.
+  ASSERT_NE(stored, raw);
+  std::remove(path.c_str());
+}
+
+//-----------------------------------------------------
+// Large workload: stride is exact, last record round-trips. Exercises the
+// 4 MiB I/O buffer path with many records spanning multiple buffer flushes.
+//-----------------------------------------------------
+TEST(APICRVTest, BinaryCurvesLargeStreamStride) {
+  const std::string path = "TestBinaryCurves_large.bin";
+  const std::size_t kVars = 200;
+  const std::size_t kSteps = 5000;
+  std::vector<std::string> names;
+  names.reserve(kVars);
+  for (std::size_t i = 0; i < kVars; ++i)
+    names.emplace_back("var_" + std::to_string(i));
+  std::vector<double> y(kVars);
+  for (std::size_t i = 0; i < kVars; ++i)
+    y[i] = static_cast<double>(i) * 0.5;
+
+  {
+    BinaryCurves bc(path, names);
+    for (std::size_t s = 0; s < kSteps; ++s)
+      bc.record(static_cast<double>(s) * 0.01, y);
+  }
+
+  const auto buf = readFile(path);
+  uint32_t n = 0;
+  std::vector<std::string> got;
+  const std::size_t off = parseHeader(buf, &n, &got);
+  ASSERT_EQ(n, kVars);
+
+  const std::size_t rowBytes = (1 + kVars) * sizeof(double);
+  ASSERT_EQ(buf.size() - off, kSteps * rowBytes);
+
+  // Spot-check the first, middle, and last records to confirm the stride
+  // and that the I/O buffer flushes did not drop or reorder bytes.
+  const std::size_t indices[] = {0, kSteps / 2, kSteps - 1};
+  for (std::size_t idx : indices) {
+    const std::size_t base = off + idx * rowBytes;
+    ASSERT_DOUBLE_EQ(readF64LE(&buf[base]),
+                     expectedRounded(static_cast<double>(idx) * 0.01));
+    for (std::size_t i = 0; i < kVars; ++i)
+      ASSERT_DOUBLE_EQ(readF64LE(&buf[base + (1 + i) * sizeof(double)]),
+                       expectedRounded(y[i]));
+  }
+  std::remove(path.c_str());
+}
+
+//-----------------------------------------------------
+// Precision::FULL stores raw IEEE-754 bits — no rounding, lossless.
+//-----------------------------------------------------
+TEST(APICRVTest, BinaryCurvesFullPrecisionLossless) {
+  const std::string path = "TestBinaryCurves_full.bin";
+  std::vector<std::string> names = {"x", "y"};
+  // Values that demonstrably do NOT survive the CSV round-trip.
+  const double t = 0.123456789012345;
+  const std::vector<double> row = {1234.123456789012, 9.876543210987e-7};
+  {
+    BinaryCurves bc(path, names, Precision::FULL);
+    bc.record(t, row);
+  }
+  const auto buf = readFile(path);
+  uint32_t n = 0;
+  std::vector<std::string> got;
+  const std::size_t off = parseHeader(buf, &n, &got);
+  // Exact bit-for-bit equality, not ASSERT_DOUBLE_EQ (which allows 4 ULPs).
+  ASSERT_EQ(readF64LE(&buf[off]), t);
+  ASSERT_EQ(readF64LE(&buf[off + sizeof(double)]), row[0]);
+  ASSERT_EQ(readF64LE(&buf[off + 2 * sizeof(double)]), row[1]);
+  std::remove(path.c_str());
+}
+
+//-----------------------------------------------------
+// CSV_ROUNDED and FULL produce different bytes for a value that the CSV
+// rounding would change, and agree on a value that survives the round-trip.
+//-----------------------------------------------------
+TEST(APICRVTest, BinaryCurvesPrecisionModesDiffer) {
+  std::vector<std::string> names = {"x"};
+  const double raw = 1234.123456789;  // changed by CSV rounding
+  const double safe = 0.5;             // exactly representable, survives rounding
+
+  const std::string pCsv = "TestBinaryCurves_csvmode.bin";
+  const std::string pFull = "TestBinaryCurves_fullmode.bin";
+  {
+    BinaryCurves bc(pCsv, names, Precision::CSV_ROUNDED);
+    bc.record(safe, std::vector<double>{raw});
+    BinaryCurves bf(pFull, names, Precision::FULL);
+    bf.record(safe, std::vector<double>{raw});
+  }
+  const auto csv = readFile(pCsv);
+  const auto full = readFile(pFull);
+  ASSERT_EQ(csv.size(), full.size());
+  uint32_t n = 0;
+  std::vector<std::string> got;
+  const std::size_t off = parseHeader(csv, &n, &got);
+
+  // Time field is identical (safe value).
+  ASSERT_EQ(readF64LE(&csv[off]), readF64LE(&full[off]));
+  ASSERT_EQ(readF64LE(&csv[off]), safe);
+
+  // Value field differs because CSV rounding actually changes raw.
+  const double csvVal = readF64LE(&csv[off + sizeof(double)]);
+  const double fullVal = readF64LE(&full[off + sizeof(double)]);
+  ASSERT_EQ(fullVal, raw);
+  ASSERT_NE(csvVal, raw);
+  ASSERT_NE(csvVal, fullVal);
+  std::remove(pCsv.c_str());
+  std::remove(pFull.c_str());
+}
+
+//-----------------------------------------------------
+// CSV_ROUNDED is the default (preserves existing behavior at call sites
+// that haven't been updated).
+//-----------------------------------------------------
+TEST(APICRVTest, BinaryCurvesCsvRoundedIsDefault) {
+  std::vector<std::string> names = {"x"};
+  const double raw = 1234.123456789;
+
+  const std::string pDef = "TestBinaryCurves_default.bin";
+  const std::string pExp = "TestBinaryCurves_explicit.bin";
+  {
+    BinaryCurves bc(pDef, names);  // no precision arg
+    bc.record(0.0, std::vector<double>{raw});
+    BinaryCurves bx(pExp, names, Precision::CSV_ROUNDED);
+    bx.record(0.0, std::vector<double>{raw});
+  }
+  const auto a = readFile(pDef);
+  const auto b = readFile(pExp);
+  ASSERT_EQ(a, b);
+  std::remove(pDef.c_str());
+  std::remove(pExp.c_str());
+}
+
+//-----------------------------------------------------
+// Variable names with zero length are encoded as just a u32(0).
+//-----------------------------------------------------
+TEST(APICRVTest, BinaryCurvesEmptyNameString) {
+  const std::string path = "TestBinaryCurves_emptyName.bin";
+  std::vector<std::string> names = {"", "tail"};
+  { BinaryCurves bc(path, names); }
+  const auto buf = readFile(path);
+  uint32_t n = 0;
+  std::vector<std::string> got;
+  parseHeader(buf, &n, &got);
+  ASSERT_EQ(n, 2u);
+  ASSERT_EQ(got[0], "");
+  ASSERT_EQ(got[1], "tail");
+  std::remove(path.c_str());
+}
+
+}  // namespace curves

--- a/dynawo/sources/API/CRV/test/TestXmlImporter.cpp
+++ b/dynawo/sources/API/CRV/test/TestXmlImporter.cpp
@@ -68,4 +68,34 @@ TEST(APICRVTest, testXmlStreamImporter) {
   ASSERT_NO_THROW(curves = importer->importFromStream(goodStream));
 }
 
+TEST(APICRVTest, testXmlStreamImporterShortcutForms) {
+  // Curve entries with only @model or only @variable are now allowed; the
+  // parsed values are kept verbatim for the downstream expansion step.
+  const std::unique_ptr<XmlImporter> importer = DYN::make_unique<XmlImporter>();
+  std::shared_ptr<CurvesCollection> curves;
+  std::istringstream goodInputStream(
+    "<?xml version='1.0' encoding='UTF-8'?>"
+    "<curvesInput xmlns=\"http://www.rte-france.com/dynawo\">"
+    "<curve model=\"GeneratorId\"/>"
+    "<curve variable=\"generator_PGen\"/>"
+    "<curve model=\"GeneratorId\" variable=\"generator_PGen\"/>"
+    "</curvesInput>");
+  std::istream goodStream(goodInputStream.rdbuf());
+  ASSERT_NO_THROW(curves = importer->importFromStream(goodStream));
+  ASSERT_NE(curves, nullptr);
+  ASSERT_EQ(curves->getCurves().size(), 3u);
+
+  const auto& c0 = curves->getCurves()[0];
+  ASSERT_EQ(c0->getModelName(), "GeneratorId");
+  ASSERT_TRUE(c0->getVariable().empty());
+
+  const auto& c1 = curves->getCurves()[1];
+  ASSERT_TRUE(c1->getModelName().empty());
+  ASSERT_EQ(c1->getVariable(), "generator_PGen");
+
+  const auto& c2 = curves->getCurves()[2];
+  ASSERT_EQ(c2->getModelName(), "GeneratorId");
+  ASSERT_EQ(c2->getVariable(), "generator_PGen");
+}
+
 }  // namespace curves

--- a/dynawo/sources/API/CRV/xsd/curvesInput.xsd
+++ b/dynawo/sources/API/CRV/xsd/curvesInput.xsd
@@ -22,16 +22,11 @@
         <xs:element name="curve" type="dyn:CurveInput" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
     </xs:complexType>
-    <xs:unique name="uniqueCurve">
-      <xs:selector xpath="dyn:curve"/>
-      <xs:field xpath="@model"/>
-      <xs:field xpath="@variable"/>
-    </xs:unique>
   </xs:element>
 
   <xs:complexType name="CurveInput">
-    <xs:attribute name="model" use="required" type="xs:string"/>
-    <xs:attribute name="variable" use="required" type="xs:string"/>
+    <xs:attribute name="model" type="xs:string"/>
+    <xs:attribute name="variable" type="xs:string"/>
     <xs:attribute name="factor" type="xs:float"/>
   </xs:complexType>
 </xs:schema>

--- a/dynawo/sources/API/JOB/xsd/jobs.xsd
+++ b/dynawo/sources/API/JOB/xsd/jobs.xsd
@@ -196,6 +196,8 @@
     <xs:restriction base="xs:string">
       <xs:enumeration value="XML"/>
       <xs:enumeration value="CSV"/>
+      <xs:enumeration value="BINARY"/>
+      <xs:enumeration value="BINARY_FAST"/>
     </xs:restriction>
   </xs:simpleType>
 

--- a/dynawo/sources/Launcher/dynawo.sh
+++ b/dynawo/sources/Launcher/dynawo.sh
@@ -120,15 +120,23 @@ jobs() {
   return ${RETURN_CODE}
 }
 
-verify_browser() {
-  if [ ! -x "$(command -v "$DYNAWO_BROWSER")" ]; then
-    error_exit "Specified browser DYNAWO_BROWSER=$DYNAWO_BROWSER not found. Use export DYNAWO_BROWSER="
-  fi
-}
-
 curves_visu() {
-  verify_browser
-  $DYNAWO_PYTHON_COMMAND "$DYNAWO_INSTALL_DIR"/sbin/curvesToHtml/curvesToHtml.py --jobsFile=$("$DYNAWO_PYTHON_COMMAND" -c "import os; print(os.path.realpath('$1'))") --withoutOffset --htmlBrowser="$DYNAWO_BROWSER" || return 1
+  local app_dir="$DYNAWO_INSTALL_DIR/sbin/curve_visualizer"
+  if ! ${DYNAWO_PYTHON_COMMAND} -c "import streamlit" >/dev/null 2>&1; then
+    error_exit "Streamlit is not installed. Run: ${DYNAWO_PYTHON_COMMAND} -m pip install -r $app_dir/requirements.txt"
+  fi
+  local resolved_paths=()
+  for f in "$@"; do
+    if [ ! -f "$f" ]; then
+      error_exit "File not found: $f"
+    fi
+    case "${f,,}" in
+      *.csv|*.bin|*.jobs) ;;
+      *) error_exit "Unsupported file type: $f (expected .csv, .bin or .jobs)" ;;
+    esac
+    resolved_paths+=("$("$DYNAWO_PYTHON_COMMAND" -c "import os; print(os.path.realpath('$f'))")")
+  done
+  ${DYNAWO_PYTHON_COMMAND} -m streamlit run "$app_dir/app.py" --server.maxUploadSize 1024 -- "${resolved_paths[@]}" || return 1
 }
 
 jobs_with_curves() {
@@ -144,9 +152,8 @@ jobs_with_curves() {
 curves() {
   set_environment
 
-  echo "Generating curves visualization pages"
-  curves_visu "$@" || error_exit "Error during curves visualisation page generation"
-  echo "End of generating curves visualization pages"
+  echo "Launching curves visualizer app"
+  curves_visu "$@" || error_exit "Error launching curves visualizer app"
   RETURN_CODE=$?
   return ${RETURN_CODE}
 }

--- a/dynawo/sources/Modeler/Common/DYNModel.h
+++ b/dynawo/sources/Modeler/Common/DYNModel.h
@@ -468,6 +468,19 @@ class Model {
   virtual bool initCurves(const std::shared_ptr<curves::Curve>& curve) = 0;
 
   /**
+   * @brief Expand shortcut curve declarations in-place.
+   *
+   * Input curves that declare only the @p model attribute are replaced by one
+   * curve per variable of that submodel; curves that declare only the
+   * @p variable attribute are replaced by one curve per submodel that exposes
+   * that variable. Fully-specified curves are kept as-is. The provided shared
+   * pointer is reseated to the expanded collection when any expansion occurs.
+   *
+   * @param curvesCollection curves collection to expand in-place
+   */
+  virtual void expandCurvesCollection(std::shared_ptr<curves::CurvesCollection>& curvesCollection) const = 0;
+
+  /**
    * @brief set the simulation working directory to use
    * @param workingDirectory Simulation working directory to use
    */

--- a/dynawo/sources/Modeler/Common/DYNModelMulti.cpp
+++ b/dynawo/sources/Modeler/Common/DYNModelMulti.cpp
@@ -21,12 +21,15 @@
 #include <vector>
 #include <string>
 #include <map>
+#include <set>
 #include <fstream>
 #include <algorithm>
 
 #include "TLTimeline.h"
 #include "CRVCurve.h"
+#include "CRVCurveFactory.h"
 #include "CRVCurvesCollection.h"
+#include "CRVCurvesCollectionFactory.h"
 #include "CSTRConstraintsCollection.h"
 
 #include "DYNMacrosMessage.h"
@@ -1088,6 +1091,87 @@ ModelMulti::initCurves(const std::shared_ptr<curves::Curve>& curve) {
   if (!curve->getAvailable())
     Trace::warn() << DYNLog(CurveNotAdded, modelName, variable) << Trace::endline;
   return curve->getAvailable();
+}
+
+void
+ModelMulti::expandCurvesCollection(std::shared_ptr<curves::CurvesCollection>& curvesCollection) const {
+  if (!curvesCollection)
+    return;
+  const auto& inputs = curvesCollection->getCurves();
+  const bool needsExpansion = std::any_of(
+      inputs.begin(), inputs.end(),
+      [](const std::shared_ptr<curves::Curve>& c) {
+        return c->getModelName().empty() || c->getVariable().empty();
+      });
+  if (!needsExpansion)
+    return;
+
+  auto expanded = std::shared_ptr<curves::CurvesCollection>(
+      curves::CurvesCollectionFactory::newInstance("expanded"));
+
+  const std::string valueSuffix = "_value";
+  for (const auto& curve : inputs) {
+    const std::string& modelName = curve->getModelName();
+    const std::string& variable = curve->getVariable();
+    if (!modelName.empty() && !variable.empty()) {
+      expanded->add(curve);
+      continue;
+    }
+    if (modelName.empty() && variable.empty()) {
+      Trace::warn() << DYNLog(CurveNotAdded, "(empty)", "(empty)") << Trace::endline;
+      continue;
+    }
+    if (variable.empty()) {
+      // model="X" shortcut: expand to every variable of submodel X.
+      const auto it = subModelByName_.find(modelName);
+      if (it == subModelByName_.end()) {
+        Trace::warn() << DYNLog(CurveNotAdded, modelName, "*") << Trace::endline;
+        continue;
+      }
+      const auto& sub = subModels_[it->second];
+      const auto& byName = sub->getVariableByName();
+      // Prefer the bare form when a `foo` / `foo_value` pair coexists; drop
+      // the `_value` entry so the expansion emits each variable only once.
+      std::set<std::string> names;
+      for (const auto& kv : byName) {
+        const std::string& nm = kv.first;
+        if (nm.size() > valueSuffix.size() &&
+            nm.compare(nm.size() - valueSuffix.size(), valueSuffix.size(), valueSuffix) == 0) {
+          const std::string bare = nm.substr(0, nm.size() - valueSuffix.size());
+          if (byName.count(bare))
+            continue;  // bare form already picked up, skip the `_value` twin
+          names.insert(bare);
+        } else {
+          names.insert(nm);
+        }
+      }
+      for (const auto& nm : names) {
+        std::shared_ptr<curves::Curve> newCurve = curves::CurveFactory::newCurve();
+        newCurve->setModelName(modelName);
+        newCurve->setVariable(nm);
+        newCurve->setFactor(curve->getFactor());
+        newCurve->setExportType(curve->getExportType());
+        expanded->add(newCurve);
+      }
+    } else {
+      // variable="V" shortcut: expand across all submodels exposing V.
+      bool matched = false;
+      for (const auto& sub : subModels_) {
+        if (sub->hasVariable(variable) || sub->hasVariable(variable + valueSuffix)) {
+          std::shared_ptr<curves::Curve> newCurve = curves::CurveFactory::newCurve();
+          newCurve->setModelName(sub->name());
+          newCurve->setVariable(variable);
+          newCurve->setFactor(curve->getFactor());
+          newCurve->setExportType(curve->getExportType());
+          expanded->add(newCurve);
+          matched = true;
+        }
+      }
+      if (!matched)
+        Trace::warn() << DYNLog(CurveNotAdded, "*", variable) << Trace::endline;
+    }
+  }
+  curvesCollection = std::move(expanded);
 }
 
 void

--- a/dynawo/sources/Modeler/Common/DYNModelMulti.h
+++ b/dynawo/sources/Modeler/Common/DYNModelMulti.h
@@ -376,6 +376,11 @@ class ModelMulti : public Model, private boost::noncopyable {
    */
   bool initCurves(const std::shared_ptr<curves::Curve>& curve) override;
 
+  /**
+   * @copydoc Model::expandCurvesCollection(std::shared_ptr<curves::CurvesCollection>&)
+   */
+  void expandCurvesCollection(std::shared_ptr<curves::CurvesCollection>& curvesCollection) const override;
+
  public:
   /**
    * @brief add a sub model to the model multi container

--- a/dynawo/sources/Simulation/DYNSimulation.cpp
+++ b/dynawo/sources/Simulation/DYNSimulation.cpp
@@ -57,6 +57,7 @@
 #include "CRVCurve.h"
 #include "CRVXmlExporter.h"
 #include "CRVCsvExporter.h"
+#include "CRVBinaryCurves.h"
 
 #include "FSVFinalStateValuesCollectionFactory.h"
 #include "FSVFinalStateValuesCollection.h"
@@ -239,6 +240,8 @@ wasLoggingEnabled_(false) {
   configureCriteria();
 }
 
+Simulation::~Simulation() = default;
+
 void
 Simulation::configureSimulationInputs() {
   //---- dydFile ----
@@ -418,6 +421,12 @@ Simulation::configureCurveOutputs() {
     } else if (exportMode == "XML") {
       exportModeFlag = Simulation::EXPORT_CURVES_XML;
       outputFile = createAbsolutePath("curves.xml", curvesDir);
+    } else if (exportMode == "BINARY") {
+      exportModeFlag = Simulation::EXPORT_CURVES_BINARY;
+      outputFile = createAbsolutePath("curves.bin", curvesDir);
+    } else if (exportMode == "BINARY_FAST") {
+      exportModeFlag = Simulation::EXPORT_CURVES_BINARY_FAST;
+      outputFile = createAbsolutePath("curves.bin", curvesDir);
     } else {
       throw DYNError(Error::MODELER, UnknownCurvesExport, exportMode);
     }
@@ -890,6 +899,9 @@ Simulation::init() {
   Trace::info() << "-----------------------------------------------------------------------" << Trace::endline;
   Trace::info() << DYNLog(CurveInit) << Trace::endline;
   Trace::info() << "-----------------------------------------------------------------------" << Trace::endline;
+  // Expand shortcut <curve model="..."/> and <curve variable="..."/> entries
+  // against the composed model now that subModels are fully built.
+  model_->expandCurvesCollection(curvesCollection_);
   const std::vector<double>& y = solver_->getCurrentY();
   unsigned nbCurves = 0;
   for (const auto& curve : curvesCollection_->getCurves()) {
@@ -984,6 +996,17 @@ Simulation::simulate() {
   if (exportCurvesMode_ != EXPORT_CURVES_NONE) {
     // This is a workaround to update the calculated variables with initial values of y and yp as they are not accessible at this level
     model_->evalCalculatedVariables(tCurrent_, solver_->getCurrentY(), solver_->getCurrentYP(), zCurrent_);
+  }
+  if ((exportCurvesMode_ == EXPORT_CURVES_BINARY || exportCurvesMode_ == EXPORT_CURVES_BINARY_FAST) &&
+      !curvesOutputFile_.empty()) {
+    std::vector<std::string> names;
+    names.reserve(model_->sizeY());
+    for (int i = 0; i < model_->sizeY(); ++i)
+      names.push_back(model_->getVariableName(i));
+    const curves::Precision precision = (exportCurvesMode_ == EXPORT_CURVES_BINARY_FAST)
+                                            ? curves::Precision::FULL
+                                            : curves::Precision::CSV_ROUNDED;
+    binaryCurves_.reset(new curves::BinaryCurves(curvesOutputFile_, names, precision));
   }
   constexpr bool updateCalculatedVariable = false;
   updateCurves(updateCalculatedVariable);  // initial curves
@@ -1218,6 +1241,9 @@ Simulation::updateCurves(const bool updateCalculatedVariable) const {
     model_->updateCalculatedVarForCurves();
 
   curvesCollection_->updateCurves(tCurrent_);
+
+  if (binaryCurves_)
+    binaryCurves_->record(tCurrent_, solver_->getCurrentY());
 }
 
 void
@@ -1274,7 +1300,12 @@ Simulation::terminate() {
 #endif
   updateParametersValues();   // update parameter curves' value
 
-  if (!curvesOutputFile_.empty()) {
+  if (binaryCurves_)
+    binaryCurves_.reset();  // flush and close the streaming binary curves file
+
+  if (!curvesOutputFile_.empty() &&
+      exportCurvesMode_ != EXPORT_CURVES_BINARY &&
+      exportCurvesMode_ != EXPORT_CURVES_BINARY_FAST) {
     ofstream fileCurves;
     openFileStream(fileCurves, curvesOutputFile_);
     printCurves(fileCurves);
@@ -1359,6 +1390,10 @@ Simulation::printCurves(std::ostream& stream) const {
       csvExporter.exportToStream(curvesCollection_, stream);
       break;
     }
+    case EXPORT_CURVES_BINARY:
+    case EXPORT_CURVES_BINARY_FAST:
+      // Records are streamed to disk by BinaryCurves as the simulation runs; nothing to do here.
+      break;
   }
 }
 

--- a/dynawo/sources/Simulation/DYNSimulation.h
+++ b/dynawo/sources/Simulation/DYNSimulation.h
@@ -45,6 +45,7 @@ class Timeline;
 
 namespace curves {
 class CurvesCollection;
+class BinaryCurves;
 }
 
 namespace constraints {
@@ -84,7 +85,9 @@ class Simulation {
   typedef enum {
     EXPORT_CURVES_NONE,  ///< Export zero curves
     EXPORT_CURVES_XML,  ///< Export curves selected in input file in XML mode in output file
-    EXPORT_CURVES_CSV  ///< Export curves selected in input file in CSV mode in output file
+    EXPORT_CURVES_CSV,  ///< Export curves selected in input file in CSV mode in output file
+    EXPORT_CURVES_BINARY,  ///< Stream the full solution vector to a binary file (values rounded to CSV precision)
+    EXPORT_CURVES_BINARY_FAST  ///< Stream the full solution vector to a binary file (raw IEEE-754, no rounding)
   } exportCurvesMode_t;
 
   /**
@@ -164,7 +167,7 @@ class Simulation {
   /**
    * @brief default destructor
    */
-  virtual ~Simulation() {}
+  virtual ~Simulation();
 
   /**
    * @brief initialize the simulation
@@ -699,6 +702,7 @@ class Simulation {
   boost::shared_ptr<DynamicData> dyd_;  ///< Dynamic data container associated to the job
   boost::shared_ptr<timeline::Timeline> timeline_;  ///< instance of the timeline where events are stored
   std::shared_ptr<curves::CurvesCollection> curvesCollection_;  ///< instance of curves collection where curves are stored
+  std::unique_ptr<curves::BinaryCurves> binaryCurves_;  ///< optional streaming binary writer for the full solution vector
   std::shared_ptr<constraints::ConstraintsCollection> constraintsCollection_;  ///< instance of constraints collection where constraints are stored
   std::shared_ptr<criteria::CriteriaCollection> criteriaCollection_;  ///< instance of criteria collection where criteria are stored
   std::shared_ptr<std::vector<

--- a/util/curve_visualizer/README.md
+++ b/util/curve_visualizer/README.md
@@ -1,0 +1,91 @@
+# Curve Visualizer
+
+Interactive Streamlit app for plotting Dynawo curves, plus a command-line
+utility for working with binary (`.bin`) curves files.
+
+## Features
+
+- Upload any CSV file (first column = x/time axis, remaining columns = curves)
+- Upload any Dynawo `.bin` file produced by the `BINARY` curves export mode
+- Toggle each curve on/off with a checkbox
+- Assign each curve to the **left** or **right** y-axis (for different magnitude scales)
+- Automatic colors
+- Interactive zoom, pan, and hover via Plotly
+- Falls back to built-in demo data when no file is uploaded
+
+## Usage
+
+```bash
+pip install -r requirements.txt
+streamlit run app.py --server.maxUploadSize 1024
+```
+
+## CSV format
+
+```
+time,voltage,current,temperature,power
+0.0,230.1,1.23,25.0,283.0
+0.1,229.8,1.25,25.1,287.3
+...
+```
+
+## `binary_curves.py` command-line tool
+
+`binary_curves.py` is a companion script that ships alongside the app. It
+parses the same file format the Streamlit app reads, but is usable on its
+own — useful for inspecting or slicing very large `.bin` files (tens of GB)
+without opening them in the browser.
+
+### List every variable name
+
+```bash
+python binary_curves.py names simulation.bin
+# → writes simulation.names.txt with one variable name per line
+
+python binary_curves.py names simulation.bin -o vars.txt
+```
+
+Only the header is read, so this is fast even on multi-GB files.
+
+### Extract a subset of columns as CSV
+
+```bash
+# Glob-style patterns. Multiple --pattern flags are OR-combined.
+python binary_curves.py extract simulation.bin -p '*voltage*' -p 'bus?_V'
+
+# Plain substring filter (-c, repeatable, OR-combined with -p)
+python binary_curves.py extract simulation.bin -c generator
+python binary_curves.py extract simulation.bin -c generator -c load
+
+# Regular expressions (applies to --pattern only)
+python binary_curves.py extract simulation.bin --regex -p '.*theta.*'
+
+# Custom output path and number format
+python binary_curves.py extract simulation.bin -p '*' -o all.csv --fmt '%.12g'
+
+# Smaller streaming chunks for tight-memory environments
+python binary_curves.py extract simulation.bin -c generator --chunk-bytes 67108864
+```
+
+The CSV always starts with a `time` column followed by the matching variables
+in the order they appear in the file. Records are read chunk-by-chunk
+(`--chunk-bytes`, default 1 GiB), so files that do not fit in RAM are
+processed without issue.
+
+### Programmatic use
+
+```python
+from binary_curves import load_bin, read_header, extract_to_csv
+
+# Whole-file load (suits in-memory use, returns a DataFrame):
+with open("simulation.bin", "rb") as f:
+    df = load_bin(f.read())
+
+# Header-only inspection (cheap on huge files):
+with open("simulation.bin", "rb") as f:
+    header = read_header(f)
+print(header.n_vars, header.names[:5])
+
+# Streaming extract:
+extract_to_csv("simulation.bin", "subset.csv", ["*voltage*"])
+```

--- a/util/curve_visualizer/app.py
+++ b/util/curve_visualizer/app.py
@@ -1,0 +1,944 @@
+import streamlit as st
+import pandas as pd
+import plotly.graph_objects as go
+from plotly.subplots import make_subplots
+import numpy as np
+import csv as _csv
+import io
+import os
+import re
+import sys
+import xml.etree.ElementTree as ET
+
+from binary_curves import load_bin
+
+st.set_page_config(page_title="Curve Visualizer", layout="wide")
+st.title("Curve Visualizer")
+
+# ── CSV parsing helpers ──────────────────────────────────────────────────────
+
+_CSV_DELIMITERS = ";,\t|"
+
+def _detect_csv_separator(text: str) -> str:
+    """Pick a separator from a CSV sample. Tries csv.Sniffer first; falls back
+    to the delimiter that yields the highest minimum field count across the
+    first non-empty lines (handles Dynawo's `;`-with-trailing-`;` format and
+    plain `,` CSVs equally well)."""
+    sample = text[:8192]
+    try:
+        return _csv.Sniffer().sniff(sample, delimiters=_CSV_DELIMITERS).delimiter
+    except _csv.Error:
+        pass
+    candidate_lines = [l for l in sample.splitlines() if l.strip()][:5]
+    if not candidate_lines:
+        return ","
+    best = ","
+    best_min = -1
+    for sep in _CSV_DELIMITERS:
+        m = min(l.count(sep) for l in candidate_lines)
+        if m > best_min:
+            best_min = m
+            best = sep
+    return best
+
+
+def _parse_csv_bytes(data: bytes) -> pd.DataFrame:
+    """Parse CSV bytes into a DataFrame, auto-detecting the separator and
+    dropping any trailing all-NaN ``Unnamed: N`` columns produced by Dynawo's
+    `value;value;\\n` format."""
+    text = data.decode("utf-8-sig", errors="replace")
+    sep = _detect_csv_separator(text)
+    df = pd.read_csv(io.BytesIO(data), sep=sep, encoding_errors="replace")
+    junk = [
+        c for c in df.columns
+        if isinstance(c, str) and c.startswith("Unnamed:") and df[c].isna().all()
+    ]
+    if junk:
+        df = df.drop(columns=junk)
+    return df
+
+
+# ── .jobs file resolver ──────────────────────────────────────────────────────
+
+_DYN_NS = "http://www.rte-france.com/dynawo"
+_JOBS_EXPORT_EXT = {"CSV": "csv", "BINARY": "bin"}
+
+def _resolve_jobs_file(jobs_path: str) -> "list[tuple[str, str]]":
+    """Return ``(label, abs_path)`` tuples for every curves output referenced
+    by a Dynawo .jobs file.
+
+    Walks every ``<dyn:job>``, then every ``<dyn:outputs directory="...">``,
+    then every ``<dyn:curves exportMode="..."/>`` inside it and points at
+    ``<jobs_dir>/<directory>/curves/curves.{csv,bin}``. The label is built
+    from the outputs directory so multi-job .jobs files (different
+    ``directory`` per job) produce distinguishable entries:
+
+        outputsRunning/curves.csv
+        outputsOmega/curves.csv
+        outputsPVar/curves.csv
+
+    XML curves output is skipped — the visualizer only loads CSV and binary.
+    """
+    base = os.path.dirname(os.path.abspath(jobs_path))
+    found: "list[tuple[str, str]]" = []
+    root = ET.parse(jobs_path).getroot()
+    for job in root.iter(f"{{{_DYN_NS}}}job"):
+        for outputs in job.iter(f"{{{_DYN_NS}}}outputs"):
+            directory = outputs.get("directory")
+            if not directory:
+                continue
+            for curves_el in outputs.iter(f"{{{_DYN_NS}}}curves"):
+                ext = _JOBS_EXPORT_EXT.get(curves_el.get("exportMode", ""))
+                if ext is None:
+                    continue
+                path = os.path.join(base, directory, "curves", f"curves.{ext}")
+                if os.path.isfile(path):
+                    found.append((f"{directory}/curves.{ext}", os.path.abspath(path)))
+    return found
+
+
+# ── CLI preload (streamlit run app.py -- file1.csv file2.bin file3.jobs) ────
+
+_SUPPORTED_DATA_EXTS = (".csv", ".bin")
+_SUPPORTED_PRELOAD_EXTS = _SUPPORTED_DATA_EXTS + (".jobs",)
+
+
+@st.cache_data(show_spinner="Loading file…")
+def _load_path_cached(path: str, mtime: float, size: int) -> pd.DataFrame:
+    """Read and parse a CSV/.bin file from disk. Cached on (path, mtime, size)
+    so Streamlit reruns don't re-read multi-GB inputs."""
+    lower = path.lower()
+    with open(path, "rb") as fh:
+        raw = fh.read()
+    if lower.endswith(".bin"):
+        return load_bin(raw)
+    if lower.endswith(".csv"):
+        return _parse_csv_bytes(raw)
+    raise ValueError(
+        f"Unsupported file type: {path!r} "
+        f"(expected one of {_SUPPORTED_DATA_EXTS})"
+    )
+
+
+def _expand_preload_path(path: str) -> "list[tuple[str, str]]":
+    """Given a path from the CLI, return ``(label, abs_path)`` tuples for
+    every data file to load. ``.jobs`` files are resolved into their
+    referenced curves outputs (one entry per ``<dyn:outputs>`` × ``<dyn:curves>``);
+    ``.csv`` / ``.bin`` paths pass through unchanged; anything else aborts."""
+    lower = path.lower()
+    if lower.endswith(".jobs"):
+        resolved = _resolve_jobs_file(path)
+        if not resolved:
+            st.error(
+                f"No CSV/BINARY curves output found for jobs file: {path}\n"
+                f"Check that the simulation has run and produced "
+                f"<outputs directory=...>/curves/curves.{{csv,bin}}."
+            )
+            st.stop()
+        return resolved
+    if lower.endswith(_SUPPORTED_DATA_EXTS):
+        return [(os.path.basename(path), os.path.abspath(path))]
+    st.error(
+        f"Unsupported preload file: {path}\n"
+        f"Supported extensions: {', '.join(_SUPPORTED_PRELOAD_EXTS)}"
+    )
+    st.stop()
+    return []  # unreachable; keeps the type checker happy
+
+
+def _disambiguate_label(label: str, used: "dict[str, pd.DataFrame]", path: str) -> str:
+    """Return a label that doesn't collide with already-loaded files. Falls
+    back to ``<parent_dir>/<basename>`` then to the absolute path."""
+    if label not in used:
+        return label
+    parent = os.path.basename(os.path.dirname(os.path.abspath(path)))
+    candidate = f"{parent}/{label}" if parent else label
+    if candidate not in used:
+        return candidate
+    return os.path.abspath(path)
+
+
+_preloaded: "dict[str, pd.DataFrame]" = {}
+_preloaded_paths: "list[tuple[str, str]]" = []
+for _arg in (a for a in sys.argv[1:] if not a.startswith("-")):
+    if not os.path.isfile(_arg):
+        st.error(f"Preload path not found: {_arg}")
+        st.stop()
+    for _label, _path in _expand_preload_path(_arg):
+        _stat = os.stat(_path)
+        _final_label = _disambiguate_label(_label, _preloaded, _path)
+        _preloaded[_final_label] = _load_path_cached(
+            _path, _stat.st_mtime, _stat.st_size
+        )
+        _preloaded_paths.append((_final_label, _path))
+
+if _preloaded_paths:
+    _unloaded: set = st.session_state.setdefault("preload_unloaded", set())
+    _active_paths = [(lbl, path) for lbl, path in _preloaded_paths if lbl not in _unloaded]
+    if _active_paths:
+        st.success(
+            "Preloaded "
+            + ", ".join(f"**{label}** (`{path}`)" for label, path in _active_paths)
+        )
+    with st.expander(
+        f"Preloaded files ({len(_active_paths)}/{len(_preloaded_paths)} active)",
+        expanded=False,
+    ):
+        for _lbl, _full in _preloaded_paths:
+            cols = st.columns([6, 1])
+            cols[0].markdown(
+                f"{'✅' if _lbl not in _unloaded else '⛔'} **{_lbl}** — `{_full}`"
+            )
+            if _lbl in _unloaded:
+                if cols[1].button("Reload", key=f"reload_{_lbl}"):
+                    _unloaded.discard(_lbl)
+                    st.rerun()
+            else:
+                if cols[1].button("Unload", key=f"unload_{_lbl}"):
+                    _unloaded.add(_lbl)
+                    st.rerun()
+    # Drop unloaded preloads before they reach the visualization layer.
+    for _lbl in list(_unloaded):
+        _preloaded.pop(_lbl, None)
+
+# ── Palettes ───────────────────────────────────────────────────────────────────
+
+COLORS = [
+    "#1f77b4", "#ff7f0e", "#2ca02c", "#d62728",
+    "#9467bd", "#8c564b", "#e377c2", "#7f7f7f",
+    "#bcbd22", "#17becf",
+]
+
+# One dash style per loaded file — same curve across files keeps its colour but
+# changes dash so simulations are visually distinguishable.
+DASHES = ["solid", "dash", "dot", "dashdot", "longdash", "longdashdot"]
+
+# ── Data loading ───────────────────────────────────────────────────────────────
+
+@st.cache_data
+def load_csv(data: bytes) -> pd.DataFrame:
+    return _parse_csv_bytes(data)
+
+@st.cache_data
+def load_bin_cached(data: bytes) -> pd.DataFrame:
+    return load_bin(data)
+
+# ── Derived curves ─────────────────────────────────────────────────────────────
+
+_SAFE_NAMES: dict = {
+    "abs": np.abs, "sqrt": np.sqrt, "exp": np.exp,
+    "log": np.log, "log2": np.log2, "log10": np.log10,
+    "sin": np.sin, "cos": np.cos, "tan": np.tan,
+    "arcsin": np.arcsin, "arccos": np.arccos,
+    "arctan": np.arctan, "arctan2": np.arctan2,
+    "sinh": np.sinh, "cosh": np.cosh, "tanh": np.tanh,
+    "minimum": np.minimum, "maximum": np.maximum,
+    "clip": np.clip, "sign": np.sign,
+    "floor": np.floor, "ceil": np.ceil, "round": np.round,
+    "where": np.where,
+    "pi": np.pi, "e": np.e,
+}
+
+_BACKTICK_RE = re.compile(r"`([^`]+)`")
+
+
+def _tok(col: str) -> str:
+    """Return `col` if it's a valid Python identifier, else wrap in backticks."""
+    return col if col.isidentifier() else f"`{col}`"
+
+
+def _on_add_derived(label: str, expr_key: str, existing_cols: set[str]) -> None:
+    """Callback for the guided builder's "Add" button.
+
+    Runs before widgets are re-instantiated on the resulting rerun, so it may
+    mutate ``st.session_state[expr_key]`` (the text area feeding `apply_derived`).
+    """
+    err_key = f"derived_form_err__{label}"
+    op = st.session_state.get(f"derived_op__{label}")
+    new_name = st.session_state.get(f"derived_name__{label}", "").strip()
+
+    err: str | None = None
+    expr: str | None = None
+
+    if not new_name:
+        err = "Give the new curve a name."
+    elif not new_name.isidentifier():
+        err = f"Invalid name `{new_name}` (must be a plain identifier)."
+    elif new_name in existing_cols:
+        err = f"`{new_name}` is already a defined curve."
+    elif op == "sum":
+        sel = st.session_state.get(f"derived_sum__{label}", []) or []
+        if len(sel) < 2:
+            err = "Pick at least two curves to sum."
+        else:
+            expr = " + ".join(_tok(c) for c in sel)
+    elif op == "product":
+        sel = st.session_state.get(f"derived_prod__{label}", []) or []
+        if len(sel) < 2:
+            err = "Pick at least two curves to multiply."
+        else:
+            expr = " * ".join(_tok(c) for c in sel)
+    elif op == "scale":
+        curve  = st.session_state.get(f"derived_scale_curve__{label}")
+        factor = st.session_state.get(f"derived_scale_factor__{label}", 1.0)
+        if curve is None:
+            err = "Pick a curve to scale."
+        else:
+            expr = f"{factor:g} * {_tok(curve)}"
+    elif op == "modulus":
+        re_c = st.session_state.get(f"derived_mod_re__{label}")
+        im_c = st.session_state.get(f"derived_mod_im__{label}")
+        if re_c is None or im_c is None:
+            err = "Pick both real and imaginary parts."
+        else:
+            expr = f"sqrt({_tok(re_c)}**2 + {_tok(im_c)}**2)"
+    elif op == "log":
+        curve = st.session_state.get(f"derived_log_curve__{label}")
+        base  = st.session_state.get(f"derived_log_base__{label}", "e")
+        if curve is None:
+            err = "Pick a curve."
+        else:
+            fn = {"e": "log", "10": "log10", "2": "log2"}[base]
+            expr = f"{fn}({_tok(curve)})"
+
+    if err or expr is None:
+        st.session_state[err_key] = err or "Unknown error"
+        return
+
+    st.session_state[err_key] = ""
+    cur = st.session_state.get(expr_key, "")
+    sep = "" if (not cur or cur.endswith("\n")) else "\n"
+    st.session_state[expr_key] = cur + sep + f"{new_name} = {expr}"
+
+
+def apply_derived(df: pd.DataFrame, spec: str) -> tuple[pd.DataFrame, list[str]]:
+    """Parse `name = expr` lines; append derived columns. Returns (df, errors).
+
+    A later line may reference a curve defined by an earlier successful line.
+    Duplicate definitions and attempts to override a source column are rejected.
+    """
+    errors: list[str] = []
+    if not spec.strip():
+        return df, errors
+    df = df.copy()
+    source_cols = set(df.columns)
+    defined: set[str] = set()
+    time_col = df.columns[0]
+    for lineno, raw_line in enumerate(spec.splitlines(), 1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            errors.append(f"line {lineno}: missing '=' in `{raw_line}`")
+            continue
+        name, expr = line.split("=", 1)
+        name, expr = name.strip(), expr.strip()
+        if not name.isidentifier():
+            errors.append(f"line {lineno}: invalid curve name `{name}`")
+            continue
+        if name == time_col:
+            errors.append(f"line {lineno}: cannot override time column `{name}`")
+            continue
+        if name in source_cols:
+            errors.append(f"line {lineno}: cannot override source column `{name}`")
+            continue
+        if name in defined:
+            errors.append(f"line {lineno}: `{name}` is already defined earlier")
+            continue
+        placeholders: dict[str, str] = {}
+        def _sub(m: re.Match) -> str:
+            key = f"__col_{len(placeholders)}"
+            placeholders[key] = m.group(1)
+            return key
+        rewritten = _BACKTICK_RE.sub(_sub, expr)
+        missing = [c for c in placeholders.values() if c not in df.columns]
+        if missing:
+            errors.append(f"line {lineno}: unknown column(s) {missing}")
+            continue
+        ns: dict = dict(_SAFE_NAMES)
+        for c in df.columns:
+            if c.isidentifier():
+                ns[c] = df[c]
+        for key, col in placeholders.items():
+            ns[key] = df[col]
+        try:
+            df[name] = eval(rewritten, {"__builtins__": {}}, ns)
+        except Exception as exc:
+            errors.append(f"line {lineno} (`{name}`): {exc}")
+            continue
+        defined.add(name)
+    return df, errors
+
+
+@st.cache_data
+def generate_demo(seed: int = 0) -> pd.DataFrame:
+    rng = np.random.default_rng(seed)
+    t = np.linspace(0, 10, 500)
+    phase = rng.uniform(0, 0.5)
+    scale = rng.uniform(0.8, 1.2)
+    return pd.DataFrame({
+        "time":        t,
+        "sine":        scale * np.sin(2 * np.pi * t / 5 + phase),
+        "cosine":      scale * np.cos(2 * np.pi * t / 5 + phase),
+        "exp_decay":   np.exp(-t / (3 + rng.uniform(-0.5, 0.5))),
+        "linear":      (0.1 + rng.uniform(-0.02, 0.02)) * t - 0.5,
+        "large_scale": 1000 * scale * np.sin(2 * np.pi * t / 8 + 1 + phase),
+    })
+
+uploaded_files = st.file_uploader(
+    "Upload one or more CSV or binary (.bin) files "
+    "(first column = time/x axis, remaining = curves)",
+    type=["csv", "bin"],
+    accept_multiple_files=True,
+)
+
+files: dict[str, pd.DataFrame] = dict(_preloaded)
+if uploaded_files:
+    for f in uploaded_files:
+        raw = f.read()
+        if f.name.endswith(".bin"):
+            files[f.name] = load_bin_cached(raw)
+        else:
+            files[f.name] = load_csv(raw)
+
+if not files:
+    st.info("Please upload one or more CSV or binary (.bin) files to visualize.")
+    st.stop()
+
+file_labels = list(files.keys())
+
+# ── Derived curves UI ──────────────────────────────────────────────────────────
+
+with st.expander("Derived curves", expanded=False):
+    st.caption(
+        "Define new curves as `name = expression`, one per line. "
+        "Wrap column names containing dots in backticks (e.g. `` `resistor.R` ``). "
+        "Available: `sqrt`, `exp`, `log`/`log2`/`log10`, `sin`/`cos`/`tan`, "
+        "`arctan2`, `abs`, `sign`, `where`, `minimum`/`maximum`, `clip`, `pi`, `e`."
+    )
+    if len(file_labels) > 1:
+        containers = st.tabs(file_labels)
+    else:
+        containers = [st.container()]
+    for container, label in zip(containers, file_labels):
+        with container:
+            expr_key  = f"derived__{label}"
+            pick_key  = f"derived_pick__{label}"
+            ins_key   = f"derived_ins__{label}"
+
+            # Evaluate the current spec up front so derived curves become
+            # selectable in the Insert picker and in the guided builder below.
+            spec_current = st.session_state.get(expr_key, "")
+            working_df, derived_errs = apply_derived(files[label], spec_current)
+            files[label] = working_df
+            curve_cols    = list(working_df.columns[1:])
+            existing_cols = set(working_df.columns)
+
+            pick_col, btn_col = st.columns([4, 1])
+            with pick_col:
+                picked = st.selectbox(
+                    "Column to insert",
+                    options=curve_cols,
+                    key=pick_key,
+                    index=None,
+                    placeholder="Pick a column (type to filter)…",
+                    label_visibility="collapsed",
+                )
+            with btn_col:
+                if st.button(
+                    "Insert",
+                    key=ins_key,
+                    use_container_width=True,
+                    disabled=picked is None,
+                ):
+                    token = _tok(picked)
+                    cur = st.session_state.get(expr_key, "")
+                    sep = "" if (not cur or cur[-1] in " \t\n(=+-*/,") else " "
+                    st.session_state[expr_key] = cur + sep + token
+
+            st.text_area(
+                f"Expressions for {label}",
+                key=expr_key,
+                height=120,
+                placeholder="magnitude = sqrt(re**2 + im**2)\ntotal = sine + cosine\nscaled = 2.5 * sine",
+                label_visibility="collapsed",
+            )
+            for err in derived_errs:
+                st.error(err)
+
+            # --- Guided builder ------------------------------------------------
+            st.divider()
+            st.markdown("**Guided builder**")
+
+            op_col, name_col = st.columns([2, 3])
+            with op_col:
+                op = st.selectbox(
+                    "Operation",
+                    options=["sum", "product", "scale", "modulus", "log"],
+                    key=f"derived_op__{label}",
+                )
+            with name_col:
+                new_name = st.text_input(
+                    "New curve name",
+                    key=f"derived_name__{label}",
+                    placeholder="e.g. magnitude",
+                )
+
+            sum_sel = prod_sel = None
+            scale_curve = log_curve = None
+            factor = None
+            re_c = im_c = None
+            base = None
+
+            if op == "sum":
+                sum_sel = st.multiselect(
+                    "Curves to sum",
+                    options=curve_cols,
+                    key=f"derived_sum__{label}",
+                )
+            elif op == "product":
+                prod_sel = st.multiselect(
+                    "Curves to multiply",
+                    options=curve_cols,
+                    key=f"derived_prod__{label}",
+                )
+            elif op == "scale":
+                c1, c2 = st.columns([3, 2])
+                with c1:
+                    scale_curve = st.selectbox(
+                        "Curve",
+                        options=curve_cols,
+                        key=f"derived_scale_curve__{label}",
+                        index=None,
+                        placeholder="Pick a curve…",
+                    )
+                with c2:
+                    factor = st.number_input(
+                        "Factor",
+                        value=1.0,
+                        key=f"derived_scale_factor__{label}",
+                        format="%g",
+                    )
+            elif op == "modulus":
+                c1, c2 = st.columns(2)
+                with c1:
+                    re_c = st.selectbox(
+                        "Real part",
+                        options=curve_cols,
+                        key=f"derived_mod_re__{label}",
+                        index=None,
+                        placeholder="Real…",
+                    )
+                with c2:
+                    im_c = st.selectbox(
+                        "Imaginary part",
+                        options=curve_cols,
+                        key=f"derived_mod_im__{label}",
+                        index=None,
+                        placeholder="Imaginary…",
+                    )
+            elif op == "log":
+                c1, c2 = st.columns([3, 2])
+                with c1:
+                    log_curve = st.selectbox(
+                        "Curve",
+                        options=curve_cols,
+                        key=f"derived_log_curve__{label}",
+                        index=None,
+                        placeholder="Pick a curve…",
+                    )
+                with c2:
+                    base = st.selectbox(
+                        "Base",
+                        options=["e", "10", "2"],
+                        key=f"derived_log_base__{label}",
+                    )
+
+            st.button(
+                "Add to expressions",
+                key=f"derived_add_form__{label}",
+                type="primary",
+                on_click=_on_add_derived,
+                args=(label, expr_key, existing_cols),
+            )
+            form_err = st.session_state.get(f"derived_form_err__{label}", "")
+            if form_err:
+                st.warning(form_err)
+
+# Collect all unique curve columns across all files (preserving first-seen order)
+all_curve_cols: list[str] = []
+_seen: set[str] = set()
+for df in files.values():
+    for col in list(df.columns[1:]):
+        if col not in _seen:
+            all_curve_cols.append(col)
+            _seen.add(col)
+
+# Stable colour per curve name, stable dash per file
+col_color  = {col: COLORS[i % len(COLORS)] for i, col in enumerate(all_curve_cols)}
+file_dash  = {lbl: DASHES[i % len(DASHES)]  for i, lbl in enumerate(file_labels)}
+
+# When there are many curves, default everything to hidden so the app does not
+# try to render hundreds of traces on load.  Users can then selectively enable
+# the curves they care about.
+MANY_CURVES_THRESHOLD = 10
+many_curves = len(all_curve_cols) > MANY_CURVES_THRESHOLD
+
+def safe_key(*parts: str) -> str:
+    """Build a widget key that is safe regardless of file/column names."""
+    return "__".join(str(p) for p in parts)
+
+
+# -- Multiselect state workaround ------------------------------------------------
+# Streamlit sometimes drops a multiselect's session_state when the `options` list
+# changes between reruns (e.g. a derived curve is added via Ctrl+Enter in the
+# expressions text area).  We mirror each relevant multiselect's value into a
+# separate slot keyed ``managed__<widget_key>`` via an on_change callback, and
+# restore it back to the widget's key just before the widget instantiates.
+
+def _save_multiselect_to_managed(widget_key: str) -> None:
+    """on_change callback: copy the widget's current value into its managed slot."""
+    st.session_state[f"managed__{widget_key}"] = list(
+        st.session_state.get(widget_key, [])
+    )
+
+
+def _restore_multiselect(widget_key: str, valid_options: list[str]) -> None:
+    """Re-seed ``session_state[widget_key]`` from its managed slot.
+
+    Filters the saved selection to only items present in ``valid_options``.
+    Must be called *before* the multiselect with ``key=widget_key`` renders.
+    """
+    managed_key = f"managed__{widget_key}"
+    saved = [x for x in st.session_state.get(managed_key, []) if x in valid_options]
+    st.session_state[managed_key] = saved
+    st.session_state[widget_key]  = saved
+
+# ── Tabs ───────────────────────────────────────────────────────────────────────
+
+tab_overlay, tab_grid = st.tabs(["Overlay", "Grid"])
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TAB 1 – OVERLAY
+# ══════════════════════════════════════════════════════════════════════════════
+
+with tab_overlay:
+    ctrl_col, plot_col = st.columns([1, 3])
+
+    # settings[(file_label, col)] = {enabled, axis}
+    ov_settings: dict[tuple[str, str], dict] = {}
+
+    with ctrl_col:
+        if many_curves:
+            st.caption(
+                f"{len(all_curve_cols)} curves — select variables to plot using the pickers below."
+            )
+        for fi, (label, df) in enumerate(files.items()):
+            curve_cols = list(df.columns[1:])
+            dash_name  = file_dash[label]
+            # Small dash-style preview next to simulation name
+            dash_css = {
+                "solid":       "4px solid",
+                "dash":        "4px dashed",
+                "dot":         "4px dotted",
+                "dashdot":     "4px dashed",   # approximation in CSS
+                "longdash":    "4px dashed",
+                "longdashdot": "4px dashed",
+            }[dash_name]
+            with st.expander(f"**{label}**", expanded=not many_curves):
+                if many_curves:
+                    ov_left_key  = safe_key("ov_left", fi)
+                    ov_right_key = safe_key("ov_right", fi)
+                    _restore_multiselect(ov_left_key,  curve_cols)
+                    _restore_multiselect(ov_right_key, curve_cols)
+                    left_sel = st.multiselect(
+                        "Left axis",
+                        options=curve_cols,
+                        key=ov_left_key,
+                        on_change=_save_multiselect_to_managed,
+                        args=(ov_left_key,),
+                    )
+                    right_sel = st.multiselect(
+                        "Right axis",
+                        options=curve_cols,
+                        key=ov_right_key,
+                        on_change=_save_multiselect_to_managed,
+                        args=(ov_right_key,),
+                    )
+                    for col in curve_cols:
+                        in_left  = col in left_sel
+                        in_right = col in right_sel
+                        ov_settings[(label, col)] = {
+                            "enabled": in_left or in_right,
+                            # right_sel takes priority if listed in both
+                            "axis": "Right" if in_right else "Left",
+                        }
+                else:
+                    for col in curve_cols:
+                        color = col_color[col]
+                        st.markdown(
+                            f'<span style="display:inline-block;width:20px;height:3px;'
+                            f'border-top:{dash_css} {color};vertical-align:middle;'
+                            f'margin-right:6px"></span>**{col}**',
+                            unsafe_allow_html=True,
+                        )
+                        c1, c2 = st.columns([1, 2])
+                        with c1:
+                            enabled = st.checkbox(
+                                "Show", value=False,
+                                key=safe_key("ov_show", fi, col),
+                            )
+                        with c2:
+                            axis = st.radio(
+                                "Y axis",
+                                options=["Left", "Right"],
+                                horizontal=True,
+                                key=safe_key("ov_axis", fi, col),
+                                label_visibility="collapsed",
+                            )
+                        ov_settings[(label, col)] = {"enabled": enabled, "axis": axis}
+
+    with plot_col:
+        has_left = any(
+            cfg["axis"] == "Left"
+            for (_, col), cfg in ov_settings.items()
+            if cfg["enabled"]
+        )
+        has_right = any(
+            cfg["axis"] == "Right"
+            for (_, col), cfg in ov_settings.items()
+            if cfg["enabled"]
+        )
+
+        fig = make_subplots(specs=[[{"secondary_y": True}]])
+
+        for (label, col), cfg in ov_settings.items():
+            if not cfg["enabled"]:
+                continue
+            df = files[label]
+            if col not in df.columns:
+                continue
+            x_col = df.columns[0]
+            fig.add_trace(
+                go.Scatter(
+                    x=df[x_col], y=df[col],
+                    name=f"{col} [{label}]",
+                    legendgroup=col,
+                    line=dict(color=col_color[col], dash=file_dash[label]),
+                    mode="lines",
+                ),
+                secondary_y=(cfg["axis"] == "Right"),
+            )
+
+        # Determine a sensible x-axis label (use first file's x column name)
+        x_title = list(files.values())[0].columns[0]
+        fig.update_layout(
+            height=600,
+            hovermode="x unified",
+            showlegend=True,
+            legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+            margin=dict(l=60, r=60, t=40, b=60),
+            xaxis=dict(title=x_title),
+        )
+        fig.update_yaxes(title_text="Left axis",  secondary_y=False, autorange=True,
+                         showgrid=(has_left or not has_right))
+        fig.update_yaxes(title_text="Right axis", secondary_y=True,  autorange=True,
+                         showgrid=(not has_left and has_right), visible=has_right)
+
+        st.plotly_chart(fig, use_container_width=True)
+
+        # Dash-style legend for simulations
+        legend_html = " &nbsp;&nbsp; ".join(
+            f'<span style="border-top:3px dashed {col_color.get(list(files[lbl].columns[1:2])[0], "#888") if list(files[lbl].columns[1:2]) else "#888"};'
+            f'display:inline-block;width:24px;height:0;vertical-align:middle;margin-right:4px;'
+            f'border-style:{file_dash[lbl].replace("longdash","dashed").replace("dashdot","dashed").replace("dot","dotted").replace("dash","dashed").replace("solid","solid")}"></span>{lbl}'
+            for lbl in file_labels
+        )
+        st.caption(
+            "Line style per simulation: &nbsp;"
+            + " &nbsp;|&nbsp; ".join(
+                f'<code style="border-bottom:2px {file_dash[lbl].replace("longdash","dashed").replace("dashdot","dashed").replace("dot","dotted").replace("dash","dashed")} #555">{lbl}</code>'
+                for lbl in file_labels
+            ),
+            unsafe_allow_html=True,
+        )
+
+# ══════════════════════════════════════════════════════════════════════════════
+# TAB 2 – GRID
+# ══════════════════════════════════════════════════════════════════════════════
+
+with tab_grid:
+    LAYOUTS = {
+        "1 row × 2 cols":  (1, 2),
+        "2 rows × 1 col":  (2, 1),
+        "2 rows × 2 cols": (2, 2),
+        "3 rows × 1 col":  (3, 1),
+        "1 row × 3 cols":  (1, 3),
+    }
+
+    top1, top2 = st.columns([2, 2])
+    with top1:
+        layout_choice = st.selectbox("Layout", options=list(LAYOUTS.keys()), index=2, key="grid_layout")
+    with top2:
+        shared_x = st.checkbox("Shared x axis (synchronised zoom)", value=True, key="grid_shared_x")
+
+    n_rows, n_cols = LAYOUTS[layout_choice]
+    n_panels  = n_rows * n_cols
+    panel_labels = [f"Panel {i + 1}" for i in range(n_panels)]
+
+    st.divider()
+
+    ctrl_col, plot_col = st.columns([1, 3])
+
+    gr_settings: dict[tuple[str, str], dict] = {}
+
+    with ctrl_col:
+        if many_curves:
+            st.caption(
+                f"{len(all_curve_cols)} curves — use the pickers below to assign variables to panels."
+            )
+        for fi, (label, df) in enumerate(files.items()):
+            curve_cols = list(df.columns[1:])
+            with st.expander(f"**{label}**", expanded=not many_curves):
+                if many_curves:
+                    # One multiselect per panel (left axis) replaces n_vars × n_panels widgets.
+                    panel_assignments: dict[str, tuple[int, str]] = {}
+                    for pi, plabel in enumerate(panel_labels):
+                        gr_left_key  = safe_key("gr_left",  fi, pi)
+                        gr_right_key = safe_key("gr_right", fi, pi)
+                        _restore_multiselect(gr_left_key,  curve_cols)
+                        _restore_multiselect(gr_right_key, curve_cols)
+                        sel_l = st.multiselect(
+                            f"{plabel} – Left",
+                            options=curve_cols,
+                            key=gr_left_key,
+                            on_change=_save_multiselect_to_managed,
+                            args=(gr_left_key,),
+                        )
+                        sel_r = st.multiselect(
+                            f"{plabel} – Right",
+                            options=curve_cols,
+                            key=gr_right_key,
+                            on_change=_save_multiselect_to_managed,
+                            args=(gr_right_key,),
+                        )
+                        for col in sel_l:
+                            panel_assignments[col] = (pi, "Left")
+                        for col in sel_r:
+                            panel_assignments[col] = (pi, "Right")
+                    for col in curve_cols:
+                        assignment = panel_assignments.get(col)
+                        gr_settings[(label, col)] = {
+                            "panel": assignment[0] if assignment else None,
+                            "axis":  assignment[1] if assignment else "Left",
+                        }
+                else:
+                    for col in curve_cols:
+                        color = col_color[col]
+                        st.markdown(
+                            f'<span style="display:inline-block;width:12px;height:12px;'
+                            f'border-radius:50%;background:{color};margin-right:6px"></span>'
+                            f'**{col}**',
+                            unsafe_allow_html=True,
+                        )
+                        c1, c2 = st.columns([3, 2])
+                        with c1:
+                            panel = st.selectbox(
+                                "Panel",
+                                options=["—"] + panel_labels,
+                                index=0,
+                                key=safe_key("gr_panel", fi, col),
+                                label_visibility="collapsed",
+                            )
+                        with c2:
+                            axis = st.radio(
+                                "Y",
+                                options=["L", "R"],
+                                horizontal=True,
+                                key=safe_key("gr_axis", fi, col),
+                                label_visibility="collapsed",
+                            )
+                        gr_settings[(label, col)] = {
+                            "panel": None if panel == "—" else panel_labels.index(panel),
+                            "axis":  "Left" if axis == "L" else "Right",
+                        }
+
+    with plot_col:
+        specs = [[{"secondary_y": True} for _ in range(n_cols)] for _ in range(n_rows)]
+
+        fig2 = make_subplots(
+            rows=n_rows, cols=n_cols,
+            specs=specs,
+            shared_xaxes=shared_x,
+            subplot_titles=panel_labels if n_panels > 1 else None,
+            horizontal_spacing=0.08,
+            vertical_spacing=0.12,
+        )
+
+        panels_with_right: set[int] = set()
+        panels_with_left:  set[int] = set()
+
+        for (label, col), cfg in gr_settings.items():
+            panel_idx = cfg["panel"]
+            if panel_idx is None:
+                continue
+            df = files[label]
+            if col not in df.columns:
+                continue
+            x_col = df.columns[0]
+            row_pos = panel_idx // n_cols + 1
+            col_pos = panel_idx %  n_cols + 1
+            secondary = cfg["axis"] == "Right"
+            if secondary:
+                panels_with_right.add(panel_idx)
+            else:
+                panels_with_left.add(panel_idx)
+
+            fig2.add_trace(
+                go.Scatter(
+                    x=df[x_col], y=df[col],
+                    name=f"{col} [{label}]",
+                    legendgroup=f"{col}__{label}",
+                    line=dict(color=col_color[col], dash=file_dash[label]),
+                    mode="lines",
+                ),
+                row=row_pos, col=col_pos,
+                secondary_y=secondary,
+            )
+
+        x_title = list(files.values())[0].columns[0]
+        for c in range(1, n_cols + 1):
+            key_n = (n_rows - 1) * n_cols + c
+            axis_key = "xaxis" if key_n == 1 else f"xaxis{key_n}"
+            fig2.update_layout(**{axis_key: dict(title=x_title)})
+
+        fig2.update_layout(
+            height=280 * n_rows + 60,
+            hovermode="x unified",
+            showlegend=True,
+            legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+            margin=dict(l=60, r=60, t=60, b=60),
+        )
+
+        for panel_idx in range(n_panels):
+            row_pos = panel_idx // n_cols + 1
+            col_pos = panel_idx %  n_cols + 1
+            p_has_left  = (panel_idx in panels_with_left)
+            p_has_right = (panel_idx in panels_with_right)
+            fig2.update_yaxes(autorange=True,
+                              showgrid=(p_has_left or not p_has_right),
+                              row=row_pos, col=col_pos, secondary_y=False)
+            fig2.update_yaxes(autorange=True,
+                              showgrid=(not p_has_left and p_has_right),
+                              visible=p_has_right,
+                              row=row_pos, col=col_pos, secondary_y=True)
+
+        st.plotly_chart(fig2, use_container_width=True)
+
+# ── Raw data preview ───────────────────────────────────────────────────────────
+
+with st.expander("Raw data"):
+    raw_tabs = st.tabs(file_labels)
+    for tab, (label, df) in zip(raw_tabs, files.items()):
+        with tab:
+            st.dataframe(df, use_container_width=True)

--- a/util/curve_visualizer/binary_curves.py
+++ b/util/curve_visualizer/binary_curves.py
@@ -1,0 +1,676 @@
+"""
+Reader utilities for Dynawo ``.bin`` curves files.
+
+File layout (all integers little-endian):
+
+    Header:
+      magic    : u8[4]   = b"DYNB"
+      version  : u32     = 1
+      n_vars   : u32     (number of tracked variables, NOT counting time)
+      for i in [0, n_vars):
+          name_len : u32
+          name     : u8[name_len]   (UTF-8)
+
+    Records (appended):
+      time   : f64
+      values : f64[n_vars]
+
+The module exposes:
+
+* ``load_bin(data)``        — parse a whole file given as ``bytes`` and return
+                              a pandas DataFrame. Used by the Streamlit app.
+* ``read_header(f)``        — parse just the header of an open file. Cheap
+                              even on 5 GB files because the record section
+                              is skipped.
+* ``count_records(path)``   — number of records, header-only cost.
+* a command-line interface:
+
+      python binary_curves.py names       <input.bin> [-o names.txt]
+      python binary_curves.py count       <input.bin>
+      python binary_curves.py extract     <input.bin> -p PATTERN ... [-o out.csv]
+      python binary_curves.py extract-bin <input.bin> -p PATTERN ... [-o out.bin]
+
+The ``extract`` commands stream the record section in fixed-size chunks so they
+can handle files that do not fit in RAM.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import fnmatch
+import os
+import re
+import struct
+import sys
+from dataclasses import dataclass
+from typing import BinaryIO, Iterable, Iterator, List, Optional, Sequence
+
+import numpy as np
+
+# ── Format constants ─────────────────────────────────────────────────────────
+
+MAGIC = b"DYNB"
+VERSION = 1
+HEADER_FIXED_SIZE = 12           # 4 (magic) + 4 (version) + 4 (n_vars)
+DOUBLE_SIZE = 8
+DEFAULT_CHUNK_BYTES = 1024 * 1024 * 1024  # 1 GiB working set per chunk
+
+
+@dataclass(frozen=True)
+class Header:
+    """Parsed header of a .bin file."""
+    version: int
+    n_vars: int
+    names: List[str]
+    data_offset: int          # absolute byte offset where records start
+
+    @property
+    def record_size(self) -> int:
+        return (1 + self.n_vars) * DOUBLE_SIZE
+
+
+# ── Header parsing ───────────────────────────────────────────────────────────
+
+def read_header(f: BinaryIO) -> Header:
+    """Read and validate the header from an open binary file.
+
+    On return, ``f`` is positioned at the start of the record section.
+    """
+    fixed = f.read(HEADER_FIXED_SIZE)
+    if len(fixed) != HEADER_FIXED_SIZE:
+        raise ValueError("File too short to contain a valid header")
+    magic = fixed[:4]
+    if magic != MAGIC:
+        raise ValueError(f"Invalid magic: {magic!r} (expected {MAGIC!r})")
+    version = struct.unpack_from("<I", fixed, 4)[0]
+    if version != VERSION:
+        raise ValueError(f"Unsupported version: {version}")
+    n_vars = struct.unpack_from("<I", fixed, 8)[0]
+
+    names: List[str] = []
+    for _ in range(n_vars):
+        raw_len = f.read(4)
+        if len(raw_len) != 4:
+            raise ValueError("Truncated header (reading name length)")
+        name_len = struct.unpack("<I", raw_len)[0]
+        raw_name = f.read(name_len)
+        if len(raw_name) != name_len:
+            raise ValueError("Truncated header (reading name payload)")
+        names.append(raw_name.decode("utf-8"))
+
+    return Header(
+        version=version,
+        n_vars=n_vars,
+        names=names,
+        data_offset=f.tell(),
+    )
+
+
+# ── Start-record resolution ──────────────────────────────────────────────────
+
+def _resolve_start_record(
+    data: np.ndarray,
+    t_min: Optional[float],
+    record_min: Optional[int],
+) -> int:
+    """Return the first record index to emit.
+
+    Both bounds are optional and compose by ``max`` (the more restrictive
+    start wins). ``t_min`` is matched against the monotonic non-decreasing
+    time column via ``np.searchsorted`` (zero-copy strided view of the mmap,
+    ~log N page touches). ``record_min`` is a direct index, clamped to
+    ``[0, n_records]`` so callers needn't pre-clamp it.
+    """
+    n = data.shape[0]
+    start = 0
+    if t_min is not None and n > 0:
+        start = max(start, int(np.searchsorted(data[:, 0], t_min, side="left")))
+    if record_min is not None:
+        start = max(start, max(0, min(record_min, n)))
+    return start
+
+
+# ── Record count ─────────────────────────────────────────────────────────────
+
+def _read_header_and_count(path: str) -> tuple[Header, int]:
+    """Parse the header and compute the number of records in one pass.
+
+    Touches only the names section (proportional to ``n_vars``) plus one
+    ``stat`` for the file size — no record bytes are read.
+    """
+    with open(path, "rb") as f:
+        header = read_header(f)
+    file_size = os.path.getsize(path)
+    data_bytes = file_size - header.data_offset
+    if data_bytes < 0 or data_bytes % header.record_size != 0:
+        raise ValueError(
+            f"Trailing partial record: {data_bytes} byte(s) past header is "
+            f"not a multiple of record size {header.record_size}"
+        )
+    return header, data_bytes // header.record_size
+
+
+def count_records(path: str) -> int:
+    """Return the number of records in a Dynawo .bin file.
+
+    Header-only cost: a read proportional to the names section (microseconds
+    for typical models, a few ms for very wide ones) plus one ``stat`` call.
+    No record data is read.
+    """
+    return _read_header_and_count(path)[1]
+
+
+# ── Whole-file loader (used by the Streamlit app) ────────────────────────────
+
+def load_bin(data: bytes):
+    """Parse a .bin file given as bytes and return a pandas DataFrame.
+
+    First column is ``time``; remaining columns are the variable names.
+    ``pandas`` is imported lazily so the CLI can run without it installed.
+    """
+    import io
+
+    import pandas as pd  # local import — optional dependency for CLI users
+
+    with io.BytesIO(data) as f:
+        header = read_header(f)
+        remaining = len(data) - header.data_offset
+        if remaining % header.record_size != 0:
+            raise ValueError(
+                f"Data section size {remaining} is not a multiple of "
+                f"record size {header.record_size}"
+            )
+        arr = np.frombuffer(
+            data, dtype="<f8",
+            count=(remaining // DOUBLE_SIZE),
+            offset=header.data_offset,
+        ).reshape(-1, 1 + header.n_vars)
+    return pd.DataFrame(arr, columns=["time"] + header.names)
+
+
+# ── Streaming helpers ────────────────────────────────────────────────────────
+
+def _records_per_chunk(record_size: int, chunk_bytes: int) -> int:
+    """Return at least one record per chunk, capped so each chunk fits the budget."""
+    return max(1, chunk_bytes // record_size)
+
+
+def iter_chunks(
+    f: BinaryIO,
+    header: Header,
+    chunk_bytes: int = DEFAULT_CHUNK_BYTES,
+) -> Iterator[np.ndarray]:
+    """Yield successive ``(N, 1 + n_vars)`` float64 chunks of records.
+
+    ``f`` must be positioned at the start of the record section (the state
+    ``read_header`` leaves it in). The last chunk may be smaller than the rest.
+    A trailing partial record triggers ``ValueError``.
+    """
+    row_elems = 1 + header.n_vars
+    per_chunk = _records_per_chunk(header.record_size, chunk_bytes)
+    chunk_byte_count = per_chunk * header.record_size
+    while True:
+        buf = f.read(chunk_byte_count)
+        if not buf:
+            return
+        n_bytes = len(buf)
+        if n_bytes % header.record_size != 0:
+            raise ValueError(
+                f"Trailing partial record: {n_bytes % header.record_size} "
+                "extra bytes at end of file"
+            )
+        n_records = n_bytes // header.record_size
+        yield np.frombuffer(buf, dtype="<f8", count=n_records * row_elems).reshape(
+            n_records, row_elems
+        )
+
+
+# ── Variable selection ───────────────────────────────────────────────────────
+
+def select_indices(
+    names: Sequence[str],
+    patterns: Sequence[str] = (),
+    *,
+    regex: bool = False,
+    contains: Sequence[str] = (),
+) -> List[int]:
+    """Return the indices of ``names`` matching at least one pattern.
+
+    ``patterns`` are fnmatch-style globs (``*``, ``?``, ``[seq]``) by default
+    or full regular expressions when ``regex=True``. ``contains`` are plain
+    substrings — a name matches when any of them appears anywhere in it.
+    The two filters are OR-combined; order of the result follows ``names``,
+    not the order of patterns, and duplicates are removed.
+    """
+    if not patterns and not contains:
+        return []
+    if regex:
+        pattern_matchers = [re.compile(p).search for p in patterns]
+    else:
+        pattern_matchers = [
+            (lambda n, p=p: fnmatch.fnmatchcase(n, p)) for p in patterns
+        ]
+    contains_list = list(contains)
+    return [
+        i
+        for i, n in enumerate(names)
+        if any(m(n) for m in pattern_matchers) or any(s in n for s in contains_list)
+    ]
+
+
+# ── High-level operations ────────────────────────────────────────────────────
+
+def write_variable_names(bin_path: str, txt_path: str) -> int:
+    """Write every variable name to ``txt_path``, one per line. Returns the count."""
+    with open(bin_path, "rb") as f:
+        header = read_header(f)
+    with open(txt_path, "w", encoding="utf-8") as out:
+        for name in header.names:
+            out.write(name)
+            out.write("\n")
+    return header.n_vars
+
+
+def extract_to_csv(
+    bin_path: str,
+    csv_path: str,
+    patterns: Sequence[str] = (),
+    *,
+    regex: bool = False,
+    contains: Sequence[str] = (),
+    chunk_bytes: int = DEFAULT_CHUNK_BYTES,
+    fmt: str = "%.7g",
+    t_min: Optional[float] = None,
+    record_min: Optional[int] = None,
+) -> tuple[int, int]:
+    """Extract columns matching ``patterns`` or ``contains`` to ``csv_path``.
+
+    The file is streamed chunk-by-chunk so files larger than RAM are handled
+    without issue. Each row starts with ``time`` followed by the matching
+    variables in their original order. ``t_min`` (inclusive) drops records
+    earlier than the given time; ``record_min`` is a direct index for
+    "last N points" use cases. When both are given the more restrictive
+    start wins.
+
+    Returns ``(n_matched_columns, n_records_written)``.
+    """
+    if not patterns and not contains:
+        raise ValueError("extract_to_csv: provide at least one pattern or substring")
+    with open(bin_path, "rb") as f:
+        header = read_header(f)
+    matched = select_indices(header.names, patterns, regex=regex, contains=contains)
+    if not matched:
+        raise SystemExit(
+            "No variable names matched the given patterns.\n"
+            "Use the 'names' subcommand to list what's available."
+        )
+    # +1 shift because column 0 in a record row is time.
+    selected_cols = np.array([0] + [i + 1 for i in matched], dtype=np.intp)
+    out_header = ["time"] + [header.names[i] for i in matched]
+
+    file_size = os.path.getsize(bin_path)
+    data_bytes = file_size - header.data_offset
+    if data_bytes % header.record_size != 0:
+        raise ValueError(
+            f"Data section size {data_bytes} is not a multiple of "
+            f"record size {header.record_size}"
+        )
+    n_records = data_bytes // header.record_size
+
+    with open(csv_path, "wb") as out:
+        out.write((",".join(out_header) + "\n").encode("utf-8"))
+        if n_records == 0:
+            return len(matched), 0
+        data = np.memmap(
+            bin_path, dtype="<f8", mode="r",
+            offset=header.data_offset,
+            shape=(n_records, 1 + header.n_vars),
+        )
+        start_rec = _resolve_start_record(data, t_min, record_min)
+        per_chunk = max(1, chunk_bytes // header.record_size)
+        for chunk_start in range(start_rec, n_records, per_chunk):
+            chunk_stop = min(chunk_start + per_chunk, n_records)
+            sub = data[chunk_start:chunk_stop, selected_cols]
+            np.savetxt(out, sub, fmt=fmt, delimiter=",")
+        return len(matched), n_records - start_rec
+
+
+def extract_to_bin(
+    bin_path: str,
+    out_path: str,
+    patterns: Sequence[str] = (),
+    *,
+    regex: bool = False,
+    contains: Sequence[str] = (),
+    chunk_records: int = 1_000_000,
+    t_min: Optional[float] = None,
+    record_min: Optional[int] = None,
+) -> tuple[int, int]:
+    """Extract columns matching ``patterns`` or ``contains`` to a new .bin file.
+
+    The output is itself a valid Dynawo .bin file (same DYNB header layout)
+    containing ``time`` plus the matched variables in their original order.
+    Bypassing text formatting makes this much faster than ``extract_to_csv``
+    on large files, and the result can be re-fed into any reader in this
+    module — including this same extractor for further sub-selection.
+
+    ``t_min`` (inclusive) drops records earlier than the given time. ``record_min``
+    is an absolute record index — useful for "give me the last N points" without
+    a time lookup (set ``record_min = n_records - N``). When both are given,
+    the more restrictive start wins.
+
+    Returns ``(n_matched_columns, n_records_written)``.
+    """
+    if not patterns and not contains:
+        raise ValueError("extract_to_bin: provide at least one pattern or substring")
+    with open(bin_path, "rb") as f:
+        header = read_header(f)
+    matched = select_indices(header.names, patterns, regex=regex, contains=contains)
+    if not matched:
+        raise SystemExit(
+            "No variable names matched the given patterns.\n"
+            "Use the 'names' subcommand to list what's available."
+        )
+    # +1 shift because column 0 in a record row is time; we always emit time.
+    selected_cols = np.array([0] + [i + 1 for i in matched], dtype=np.intp)
+    out_names = [header.names[i] for i in matched]
+
+    file_size = os.path.getsize(bin_path)
+    data_bytes = file_size - header.data_offset
+    if data_bytes % header.record_size != 0:
+        raise ValueError(
+            f"Data section size {data_bytes} is not a multiple of "
+            f"record size {header.record_size}"
+        )
+    n_records = data_bytes // header.record_size
+
+    with open(out_path, "wb") as out:
+        # New DYNB header for the subset.
+        out.write(MAGIC)
+        out.write(struct.pack("<I", VERSION))
+        out.write(struct.pack("<I", len(out_names)))
+        for name in out_names:
+            encoded = name.encode("utf-8")
+            out.write(struct.pack("<I", len(encoded)))
+            out.write(encoded)
+
+        if n_records == 0:
+            return len(matched), 0
+
+        # mmap the data section so column slicing is a zero-copy view and
+        # the OS pages in only what we touch.
+        data = np.memmap(
+            bin_path, dtype="<f8", mode="r",
+            offset=header.data_offset,
+            shape=(n_records, 1 + header.n_vars),
+        )
+        start_rec = _resolve_start_record(data, t_min, record_min)
+        n_emitted = n_records - start_rec
+        for chunk_start in range(start_rec, n_records, chunk_records):
+            chunk_stop = min(chunk_start + chunk_records, n_records)
+            # ascontiguousarray forces the fancy-indexed slice into a single
+            # C-contiguous block so tofile() emits one bulk write.
+            np.ascontiguousarray(data[chunk_start:chunk_stop, selected_cols]).tofile(out)
+
+    return len(matched), n_emitted
+
+
+# ── Command-line interface ───────────────────────────────────────────────────
+
+def _default_output(input_path: str, new_ext: str) -> str:
+    base, _ = os.path.splitext(input_path)
+    return base + new_ext
+
+
+def _resolve_tail_args(
+    input_path: str, args: argparse.Namespace
+) -> tuple[Optional[float], Optional[int]]:
+    """Translate CLI --tail / --tail-time / --t-min into (t_min, record_min).
+
+    --tail N         : last N records → record_min = n_records - N
+    --tail-time DT   : last DT seconds → t_min = last_record_time - DT
+    --t-min T        : passed through; composes with the tail bound by
+                       letting _resolve_start_record take the max.
+    """
+    t_min = args.t_min
+    record_min: Optional[int] = None
+    if args.tail is None and args.tail_time is None:
+        return t_min, record_min
+
+    # Need the file's record count (and maybe its last time) to translate.
+    header, n_records = _read_header_and_count(input_path)
+
+    if args.tail is not None:
+        record_min = max(0, n_records - args.tail)
+    else:  # args.tail_time is not None
+        if n_records > 0:
+            data = np.memmap(
+                input_path, dtype="<f8", mode="r",
+                offset=header.data_offset,
+                shape=(n_records, 1 + header.n_vars),
+            )
+            t_last = float(data[-1, 0])
+            tail_t_min = t_last - args.tail_time
+            t_min = tail_t_min if t_min is None else max(t_min, tail_t_min)
+    return t_min, record_min
+
+
+def _cmd_names(args: argparse.Namespace) -> int:
+    out = args.output or _default_output(args.input, ".names.txt")
+    count = write_variable_names(args.input, out)
+    print(f"Wrote {count} variable names to {out}", file=sys.stderr)
+    return 0
+
+
+def _cmd_count(args: argparse.Namespace) -> int:
+    n = count_records(args.input)
+    print(n)
+    return 0
+
+
+def _cmd_extract(args: argparse.Namespace) -> int:
+    if not args.pattern and not args.contains:
+        raise SystemExit("extract: provide at least one --pattern or --contains")
+    out = args.output or _default_output(args.input, ".extract.csv")
+    t_min, record_min = _resolve_tail_args(args.input, args)
+    n_cols, n_rows = extract_to_csv(
+        args.input,
+        out,
+        args.pattern,
+        regex=args.regex,
+        contains=args.contains,
+        chunk_bytes=args.chunk_bytes,
+        fmt=args.fmt,
+        t_min=t_min,
+        record_min=record_min,
+    )
+    print(
+        f"Wrote {n_cols} variable(s) × {n_rows} record(s) to {out}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def _cmd_extract_bin(args: argparse.Namespace) -> int:
+    if not args.pattern and not args.contains:
+        raise SystemExit("extract-bin: provide at least one --pattern or --contains")
+    out = args.output or _default_output(args.input, ".extract.bin")
+    t_min, record_min = _resolve_tail_args(args.input, args)
+    n_cols, n_rows = extract_to_bin(
+        args.input,
+        out,
+        args.pattern,
+        regex=args.regex,
+        contains=args.contains,
+        chunk_records=args.chunk_records,
+        t_min=t_min,
+        record_min=record_min,
+    )
+    print(
+        f"Wrote {n_cols} variable(s) × {n_rows} record(s) to {out}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Inspect and extract columns from Dynawo .bin curve files.",
+    )
+    sub = p.add_subparsers(dest="command", required=True)
+
+    names = sub.add_parser(
+        "names",
+        help="Dump every variable name to a text file (one per line).",
+    )
+    names.add_argument("input", help="Path to the .bin file")
+    names.add_argument(
+        "-o", "--output",
+        help="Output .txt file (default: <input>.names.txt)",
+    )
+    names.set_defaults(func=_cmd_names)
+
+    count = sub.add_parser(
+        "count",
+        help="Print the number of records in a .bin file (header-only cost). "
+             "Output goes to stdout for shell scripting.",
+    )
+    count.add_argument("input", help="Path to the .bin file")
+    count.set_defaults(func=_cmd_count)
+
+    extract = sub.add_parser(
+        "extract",
+        help="Stream-extract columns matching one or more patterns to a CSV.",
+    )
+    extract.add_argument("input", help="Path to the .bin file")
+    extract.add_argument(
+        "-p", "--pattern",
+        action="append",
+        default=[],
+        help="fnmatch-style pattern (can be repeated; OR-combined). "
+             "Examples: '*voltage*', 'bus?_V'. Use --regex for regular expressions.",
+    )
+    extract.add_argument(
+        "-c", "--contains",
+        action="append",
+        default=[],
+        help="Plain substring filter (can be repeated; OR-combined with --pattern). "
+             "Selects every variable whose name contains the given string. "
+             "Example: -c generator.",
+    )
+    extract.add_argument(
+        "--regex",
+        action="store_true",
+        help="Treat --pattern values as Python regular expressions (re.search). "
+             "Has no effect on --contains.",
+    )
+    extract.add_argument(
+        "-o", "--output",
+        help="Output .csv file (default: <input>.extract.csv)",
+    )
+    extract.add_argument(
+        "--chunk-bytes",
+        type=int,
+        default=DEFAULT_CHUNK_BYTES,
+        help=f"Streaming chunk budget in bytes (default: {DEFAULT_CHUNK_BYTES}).",
+    )
+    extract.add_argument(
+        "--fmt",
+        default="%.7g",
+        help="printf-style format for numeric values (default: %%.7g).",
+    )
+    extract.add_argument(
+        "--t-min",
+        type=float,
+        default=None,
+        help="Keep only records with time >= this value (inclusive).",
+    )
+    extract_tail = extract.add_mutually_exclusive_group()
+    extract_tail.add_argument(
+        "--tail",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Keep only the last N records of the trajectory.",
+    )
+    extract_tail.add_argument(
+        "--tail-time",
+        type=float,
+        default=None,
+        metavar="DT",
+        help="Keep only records within the last DT seconds of the trajectory "
+             "(uses the last record's time as the reference end).",
+    )
+    extract.set_defaults(func=_cmd_extract)
+
+    extract_bin = sub.add_parser(
+        "extract-bin",
+        help="Like 'extract' but writes a Dynawo .bin file instead of CSV. "
+             "Much faster on large inputs because no text formatting is done; "
+             "the output is itself a valid .bin file.",
+    )
+    extract_bin.add_argument("input", help="Path to the .bin file")
+    extract_bin.add_argument(
+        "-p", "--pattern",
+        action="append",
+        default=[],
+        help="fnmatch-style pattern (can be repeated; OR-combined). "
+             "Examples: '*voltage*', 'bus?_V'. Use --regex for regular expressions.",
+    )
+    extract_bin.add_argument(
+        "-c", "--contains",
+        action="append",
+        default=[],
+        help="Plain substring filter (can be repeated; OR-combined with --pattern).",
+    )
+    extract_bin.add_argument(
+        "--regex",
+        action="store_true",
+        help="Treat --pattern values as Python regular expressions (re.search).",
+    )
+    extract_bin.add_argument(
+        "-o", "--output",
+        help="Output .bin file (default: <input>.extract.bin)",
+    )
+    extract_bin.add_argument(
+        "--chunk-records",
+        type=int,
+        default=1_000_000,
+        help="Records processed per mmap slice (default: 1,000,000). "
+             "Bounds the transient memory of the column-slice copy.",
+    )
+    extract_bin.add_argument(
+        "--t-min",
+        type=float,
+        default=None,
+        help="Keep only records with time >= this value (inclusive).",
+    )
+    extract_bin_tail = extract_bin.add_mutually_exclusive_group()
+    extract_bin_tail.add_argument(
+        "--tail",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Keep only the last N records of the trajectory.",
+    )
+    extract_bin_tail.add_argument(
+        "--tail-time",
+        type=float,
+        default=None,
+        metavar="DT",
+        help="Keep only records within the last DT seconds of the trajectory "
+             "(uses the last record's time as the reference end).",
+    )
+    extract_bin.set_defaults(func=_cmd_extract_bin)
+
+    return p
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    args = _build_parser().parse_args(list(argv) if argv is not None else None)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/util/curve_visualizer/requirements.txt
+++ b/util/curve_visualizer/requirements.txt
@@ -1,0 +1,4 @@
+streamlit>=1.32
+plotly>=5.20
+pandas>=2.0
+numpy>=1.26

--- a/util/curve_visualizer/test_binary_curves.py
+++ b/util/curve_visualizer/test_binary_curves.py
@@ -1,0 +1,426 @@
+"""Tests for util/curve_visualizer/binary_curves.py — focused on the
+extract_to_bin path and its equivalence with the CSV extractor.
+
+Run with::
+
+    pytest util/curve_visualizer/test_binary_curves.py
+"""
+from __future__ import annotations
+
+import os
+import struct
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import binary_curves as bc  # noqa: E402
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _write_bin(path: Path, names, times, values):
+    """Build a synthetic DYNB file. ``values`` is shape (n_records, n_vars)."""
+    values = np.asarray(values, dtype="<f8")
+    times = np.asarray(times, dtype="<f8")
+    assert values.shape == (len(times), len(names))
+    with open(path, "wb") as f:
+        f.write(bc.MAGIC)
+        f.write(struct.pack("<I", bc.VERSION))
+        f.write(struct.pack("<I", len(names)))
+        for n in names:
+            b = n.encode("utf-8")
+            f.write(struct.pack("<I", len(b)))
+            f.write(b)
+        # Row-major: time then values, per record.
+        row = np.empty(1 + len(names), dtype="<f8")
+        for i, t in enumerate(times):
+            row[0] = t
+            row[1:] = values[i]
+            row.tofile(f)
+
+
+def _read_bin(path: Path):
+    """Parse a DYNB file and return (names, times, values)."""
+    with open(path, "rb") as f:
+        header = bc.read_header(f)
+        remaining = os.path.getsize(path) - header.data_offset
+        arr = np.frombuffer(
+            f.read(remaining), dtype="<f8"
+        ).reshape(-1, 1 + header.n_vars)
+    return header.names, arr[:, 0].copy(), arr[:, 1:].copy()
+
+
+# ── count_records / `count` CLI ──────────────────────────────────────────────
+
+def test_count_records_returns_record_count(tmp_path):
+    src = tmp_path / "src.bin"
+    _write_bin(
+        src, ["a", "b", "c"],
+        np.arange(7) * 0.1,
+        np.arange(21, dtype="<f8").reshape(7, 3),
+    )
+    assert bc.count_records(str(src)) == 7
+
+
+def test_count_records_zero_for_header_only(tmp_path):
+    src = tmp_path / "src.bin"
+    _write_bin(src, ["a"], np.array([]), np.empty((0, 1)))
+    assert bc.count_records(str(src)) == 0
+
+
+def test_count_records_detects_trailing_partial(tmp_path):
+    """Truncating the data section mid-record must be flagged, not rounded."""
+    src = tmp_path / "src.bin"
+    _write_bin(src, ["a"], np.array([0.0, 1.0]), np.array([[1.0], [2.0]]))
+    # Drop 3 bytes from the end to leave a partial record.
+    with open(src, "r+b") as f:
+        f.seek(0, 2)
+        n = f.tell()
+        f.truncate(n - 3)
+    with pytest.raises(ValueError):
+        bc.count_records(str(src))
+
+
+def test_count_cli_prints_integer_to_stdout(tmp_path, capsys):
+    src = tmp_path / "src.bin"
+    _write_bin(
+        src, ["x", "y"],
+        np.arange(42) * 0.1,
+        np.zeros((42, 2)),
+    )
+    rc = bc.main(["count", str(src)])
+    assert rc == 0
+    out = capsys.readouterr().out.strip()
+    assert out == "42"
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+
+def test_extract_bin_round_trip_subset(tmp_path):
+    """A subset extract is itself a valid DYNB file and preserves the
+    selected columns bit-for-bit."""
+    src = tmp_path / "src.bin"
+    names = ["alpha", "beta", "gamma", "delta"]
+    times = np.linspace(0.0, 1.0, 5)
+    values = np.arange(20, dtype="<f8").reshape(5, 4)
+    _write_bin(src, names, times, values)
+
+    out = tmp_path / "out.bin"
+    n_cols, n_rows = bc.extract_to_bin(
+        str(src), str(out), patterns=["beta", "delta"]
+    )
+    assert (n_cols, n_rows) == (2, 5)
+
+    out_names, out_times, out_vals = _read_bin(out)
+    assert out_names == ["beta", "delta"]
+    np.testing.assert_array_equal(out_times, times)
+    # Columns 1 (beta) and 3 (delta) of the source.
+    np.testing.assert_array_equal(out_vals, values[:, [1, 3]])
+
+
+def test_extract_bin_preserves_source_column_order(tmp_path):
+    """Even when patterns are given in reverse order, output columns follow
+    the source order (matches extract_to_csv behaviour)."""
+    src = tmp_path / "src.bin"
+    names = ["a", "b", "c"]
+    times = np.array([0.0, 0.1])
+    values = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    _write_bin(src, names, times, values)
+
+    out = tmp_path / "out.bin"
+    bc.extract_to_bin(str(src), str(out), patterns=["c", "a"])
+    out_names, _, out_vals = _read_bin(out)
+    assert out_names == ["a", "c"]
+    np.testing.assert_array_equal(out_vals, values[:, [0, 2]])
+
+
+def test_extract_bin_matches_extract_csv(tmp_path):
+    """Extract to .bin then to CSV from that .bin equals extract original to
+    CSV directly. This pins the semantics: the binary extract is a lossless
+    pre-stage."""
+    src = tmp_path / "src.bin"
+    names = ["x", "y", "z"]
+    times = np.linspace(0, 2, 10)
+    values = np.random.default_rng(0).standard_normal((10, 3))
+    _write_bin(src, names, times, values)
+
+    direct_csv = tmp_path / "direct.csv"
+    bc.extract_to_csv(str(src), str(direct_csv), patterns=["x", "z"])
+
+    intermediate_bin = tmp_path / "mid.bin"
+    bc.extract_to_bin(str(src), str(intermediate_bin), patterns=["x", "z"])
+    via_bin_csv = tmp_path / "via_bin.csv"
+    # Re-extract from the subset; pattern '*' would match both columns.
+    bc.extract_to_csv(str(intermediate_bin), str(via_bin_csv), patterns=["*"])
+
+    assert direct_csv.read_bytes() == via_bin_csv.read_bytes()
+
+
+def test_extract_bin_empty_data_section(tmp_path):
+    """Source with header only (zero records) writes a header-only output."""
+    src = tmp_path / "src.bin"
+    _write_bin(src, ["a", "b"], times=np.array([]), values=np.empty((0, 2)))
+
+    out = tmp_path / "out.bin"
+    n_cols, n_rows = bc.extract_to_bin(str(src), str(out), patterns=["a"])
+    assert (n_cols, n_rows) == (1, 0)
+    out_names, out_times, out_vals = _read_bin(out)
+    assert out_names == ["a"]
+    assert out_times.size == 0
+    assert out_vals.shape == (0, 1)
+
+
+def test_extract_bin_chunk_boundary(tmp_path):
+    """Records spanning multiple chunk_records slices are emitted contiguously
+    with no duplication or loss."""
+    src = tmp_path / "src.bin"
+    names = ["only"]
+    n = 1000
+    times = np.arange(n, dtype="<f8")
+    values = (times * 10.0).reshape(n, 1)
+    _write_bin(src, names, times, values)
+
+    out = tmp_path / "out.bin"
+    # chunk_records=137 forces ~8 chunks with an awkward boundary.
+    bc.extract_to_bin(
+        str(src), str(out), patterns=["only"], chunk_records=137
+    )
+    out_names, out_times, out_vals = _read_bin(out)
+    assert out_names == ["only"]
+    np.testing.assert_array_equal(out_times, times)
+    np.testing.assert_array_equal(out_vals.ravel(), values.ravel())
+
+
+def test_extract_bin_no_match(tmp_path):
+    src = tmp_path / "src.bin"
+    _write_bin(src, ["foo"], np.array([0.0]), np.array([[1.0]]))
+    out = tmp_path / "out.bin"
+    with pytest.raises(SystemExit):
+        bc.extract_to_bin(str(src), str(out), patterns=["does_not_match"])
+
+
+def test_extract_bin_requires_a_filter(tmp_path):
+    src = tmp_path / "src.bin"
+    _write_bin(src, ["a"], np.array([0.0]), np.array([[1.0]]))
+    out = tmp_path / "out.bin"
+    with pytest.raises(ValueError):
+        bc.extract_to_bin(str(src), str(out))
+
+
+def test_extract_bin_contains_filter(tmp_path):
+    src = tmp_path / "src.bin"
+    names = ["bus_a_V", "bus_a_Theta", "load_P"]
+    times = np.array([0.0, 1.0])
+    values = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
+    _write_bin(src, names, times, values)
+
+    out = tmp_path / "out.bin"
+    n_cols, _ = bc.extract_to_bin(str(src), str(out), contains=["bus_a"])
+    assert n_cols == 2
+    out_names, _, out_vals = _read_bin(out)
+    assert out_names == ["bus_a_V", "bus_a_Theta"]
+    np.testing.assert_array_equal(out_vals, values[:, [0, 1]])
+
+
+def test_extract_bin_full_precision_preserved(tmp_path):
+    """Values that the CSV exporter would round are preserved bit-for-bit
+    by the binary extract — that's the whole point of staying binary."""
+    src = tmp_path / "src.bin"
+    names = ["x"]
+    # A value that does not survive %.7g rounding.
+    raw = 1234.123456789012
+    times = np.array([0.123456789012345])
+    values = np.array([[raw]])
+    _write_bin(src, names, times, values)
+
+    out = tmp_path / "out.bin"
+    bc.extract_to_bin(str(src), str(out), patterns=["x"])
+    _, out_times, out_vals = _read_bin(out)
+    # Exact equality, not allclose: binary path is lossless.
+    assert out_times[0] == times[0]
+    assert out_vals[0, 0] == raw
+
+
+# ── Start-bound tests (t_min, record_min, --tail, --tail-time) ───────────────
+
+def _trajectory_fixture(tmp_path):
+    """Source with 10 evenly-spaced records (times 0.0, 0.1, …, 0.9)."""
+    src = tmp_path / "src.bin"
+    names = ["a", "b"]
+    times = np.round(np.arange(10) * 0.1, 8)
+    values = np.column_stack([np.arange(10) * 1.0, np.arange(10) * 10.0])
+    _write_bin(src, names, times, values)
+    return src, names, times, values
+
+
+def test_extract_bin_t_min_keeps_trajectory_tail(tmp_path):
+    src, _, times, values = _trajectory_fixture(tmp_path)
+    out = tmp_path / "out.bin"
+    n_cols, n_rows = bc.extract_to_bin(
+        str(src), str(out), patterns=["a"], t_min=0.7
+    )
+    # Inclusive: times 0.7, 0.8, 0.9 -> 3 records.
+    assert (n_cols, n_rows) == (1, 3)
+    _, out_times, out_vals = _read_bin(out)
+    np.testing.assert_array_equal(out_times, times[7:])
+    np.testing.assert_array_equal(out_vals.ravel(), values[7:, 0])
+
+
+def test_extract_bin_record_min_keeps_last_n(tmp_path):
+    """record_min lets callers say 'last N records' without a time lookup."""
+    src, _, times, values = _trajectory_fixture(tmp_path)
+    out = tmp_path / "out.bin"
+    # record_min = 10 - 4 = 6 keeps the last 4 records.
+    n_cols, n_rows = bc.extract_to_bin(
+        str(src), str(out), patterns=["a"], record_min=6
+    )
+    assert (n_cols, n_rows) == (1, 4)
+    _, out_times, out_vals = _read_bin(out)
+    np.testing.assert_array_equal(out_times, times[6:])
+    np.testing.assert_array_equal(out_vals.ravel(), values[6:, 0])
+
+
+def test_extract_bin_record_min_clamps(tmp_path):
+    """A record_min past the end clamps to 'nothing'; a negative one to 0."""
+    src, _, _, _ = _trajectory_fixture(tmp_path)
+    out = tmp_path / "out.bin"
+    _, n_rows = bc.extract_to_bin(
+        str(src), str(out), patterns=["a"], record_min=1000
+    )
+    assert n_rows == 0
+    _, n_rows = bc.extract_to_bin(
+        str(src), str(out), patterns=["a"], record_min=-5
+    )
+    assert n_rows == 10  # negative clamped to 0
+
+
+def test_extract_bin_t_min_and_record_min_take_max(tmp_path):
+    """When both are given, the more restrictive (larger) start wins."""
+    src, _, times, _ = _trajectory_fixture(tmp_path)
+    out = tmp_path / "out.bin"
+    # t_min=0.3 -> start=3; record_min=7 -> start=7; max wins.
+    _, n_rows = bc.extract_to_bin(
+        str(src), str(out), patterns=["a"], t_min=0.3, record_min=7
+    )
+    assert n_rows == 3
+    _, out_times, _ = _read_bin(out)
+    np.testing.assert_array_equal(out_times, times[7:])
+
+    # t_min=0.8 -> start=8; record_min=3 -> start=3; t_min wins.
+    _, n_rows = bc.extract_to_bin(
+        str(src), str(out), patterns=["a"], t_min=0.8, record_min=3
+    )
+    assert n_rows == 2
+    _, out_times, _ = _read_bin(out)
+    np.testing.assert_array_equal(out_times, times[8:])
+
+
+def test_extract_bin_t_min_past_end_writes_header_only(tmp_path):
+    src, _, _, _ = _trajectory_fixture(tmp_path)
+    out = tmp_path / "out.bin"
+    _, n_rows = bc.extract_to_bin(
+        str(src), str(out), patterns=["a"], t_min=10.0
+    )
+    assert n_rows == 0
+    out_names, out_times, _ = _read_bin(out)
+    assert out_names == ["a"]
+    assert out_times.size == 0
+
+
+def test_extract_csv_t_min_keeps_trajectory_tail(tmp_path):
+    src, _, times, values = _trajectory_fixture(tmp_path)
+    out_csv = tmp_path / "out.csv"
+    bc.extract_to_csv(
+        str(src), str(out_csv), patterns=["b"], t_min=0.5
+    )
+    got = out_csv.read_text().splitlines()
+    assert got[0] == "time,b"
+    # Times 0.5..0.9 -> 5 rows.
+    assert len(got) == 6
+    for row, t, v in zip(got[1:], times[5:], values[5:, 1]):
+        assert row == f"{'%.7g' % t},{'%.7g' % v}"
+
+
+def test_extract_cli_tail_records(tmp_path):
+    src, _, times, _ = _trajectory_fixture(tmp_path)
+    out = tmp_path / "out.bin"
+    rc = bc.main([
+        "extract-bin", str(src), "-p", "a", "--tail", "3", "-o", str(out),
+    ])
+    assert rc == 0
+    _, out_times, _ = _read_bin(out)
+    np.testing.assert_array_equal(out_times, times[-3:])
+
+
+def test_extract_cli_tail_time(tmp_path):
+    """--tail-time peeks the last record's time and sets t_min = t_last - DT."""
+    src, _, times, _ = _trajectory_fixture(tmp_path)
+    out = tmp_path / "out.bin"
+    # Last time is 0.9; DT=0.25 -> t_min=0.65 -> records with time >= 0.65
+    # are 0.7, 0.8, 0.9 -> 3 records.
+    rc = bc.main([
+        "extract-bin", str(src), "-p", "a", "--tail-time", "0.25",
+        "-o", str(out),
+    ])
+    assert rc == 0
+    _, out_times, _ = _read_bin(out)
+    np.testing.assert_array_equal(out_times, times[7:])
+
+
+def test_extract_cli_tail_and_t_min_compose(tmp_path):
+    """--tail bounds by record index, --t-min by time; the more restrictive
+    (later) start wins."""
+    src, _, times, _ = _trajectory_fixture(tmp_path)
+    out = tmp_path / "out.bin"
+    # --tail 6 -> start=4; --t-min 0.7 -> start=7; t_min wins.
+    rc = bc.main([
+        "extract-bin", str(src), "-p", "a",
+        "--tail", "6", "--t-min", "0.7", "-o", str(out),
+    ])
+    assert rc == 0
+    _, out_times, _ = _read_bin(out)
+    np.testing.assert_array_equal(out_times, times[7:])
+
+
+def test_extract_cli_tail_and_tail_time_mutually_exclusive(tmp_path, capsys):
+    src, _, _, _ = _trajectory_fixture(tmp_path)
+    with pytest.raises(SystemExit):
+        bc.main([
+            "extract-bin", str(src), "-p", "a",
+            "--tail", "3", "--tail-time", "0.2",
+            "-o", str(tmp_path / "out.bin"),
+        ])
+
+
+def test_extract_cli_tail_on_empty_file(tmp_path):
+    """A --tail request on a record-less file just writes the header."""
+    src = tmp_path / "src.bin"
+    _write_bin(src, ["a"], np.array([]), np.empty((0, 1)))
+    out = tmp_path / "out.bin"
+    rc = bc.main([
+        "extract-bin", str(src), "-p", "a", "--tail", "100", "-o", str(out),
+    ])
+    assert rc == 0
+    out_names, out_times, _ = _read_bin(out)
+    assert out_names == ["a"]
+    assert out_times.size == 0
+
+
+def test_extract_bin_cli(tmp_path, monkeypatch, capsys):
+    """End-to-end check of the extract-bin CLI subcommand."""
+    src = tmp_path / "src.bin"
+    _write_bin(
+        src, ["a", "b"], np.array([0.0, 1.0]),
+        np.array([[1.0, 2.0], [3.0, 4.0]]),
+    )
+    out = tmp_path / "subset.bin"
+    rc = bc.main([
+        "extract-bin", str(src), "-p", "b", "-o", str(out),
+    ])
+    assert rc == 0
+    out_names, _, out_vals = _read_bin(out)
+    assert out_names == ["b"]
+    np.testing.assert_array_equal(out_vals.ravel(), [2.0, 4.0])

--- a/util/envDynawo.sh
+++ b/util/envDynawo.sh
@@ -105,6 +105,7 @@ where [option] can be:"
         curves [arg]                          plot curves of job
         curves-reference [arg]                plot curves of job's reference
         curves-reference-same-graph [arg]     plot curves of job and job's reference on the same graph
+        curves-app [files...]                 launch the Streamlit curve visualizer app preloaded with the given .csv/.bin files (1 GiB upload limit). Pass a .jobs file to auto-resolve its curves output.
 
         =========== Distribution
         distrib                               create distribution of Dynawo
@@ -439,6 +440,7 @@ set_environment() {
   export_var_env_force DYNAWO_EXAMPLES_DIR=$DYNAWO_HOME/examples
   export_var_env DYNAWO_RESULTS_SHOW=true
   export_var_env_force DYNAWO_CURVES_TO_HTML_DIR=$DYNAWO_HOME/util/curvesToHtml
+  export_var_env_force DYNAWO_CURVE_VISUALIZER_DIR=$DYNAWO_HOME/util/curve_visualizer
   export_var_env_force DYNAWO_SCRIPTS_DIR=$DYNAWO_INSTALL_DIR/sbin
   export_var_env_force DYNAWO_NRT_DIFF_DIR=$DYNAWO_HOME/util/nrt_diff
   export_var_env_force DYNAWO_UPDATE_XML_DIR=$DYNAWO_HOME/util/updateXML
@@ -1430,11 +1432,9 @@ install_jquery() {
 }
 
 jobs_with_curves() {
-  install_jquery
   launch_jobs $@ || error_exit "Dynawo job failed."
-  echo "Generating curves visualization pages"
-  curves_visu $@ || error_exit "Error during curves visualisation page generation"
-  echo "End of generating curves visualization pages"
+  echo "Launching curves visualizer app"
+  curves_visu_app $@ || error_exit "Error launching curves visualizer app"
 }
 
 curves_visu() {
@@ -1454,6 +1454,27 @@ curves_visu_reference() {
   curves_visu $jobs
   sed -i 's/<dyn:outputs directory="reference\//<dyn:outputs directory="/' $jobs
   sed -i 's/<outputs directory="reference\//<outputs directory="/' $jobs
+}
+
+curves_visu_app() {
+  if [ $# -eq 0 ]; then
+    error_exit "curves-app: provide at least one .csv, .bin or .jobs file"
+  fi
+  if ! ${DYNAWO_PYTHON_COMMAND} -c "import streamlit" >/dev/null 2>&1; then
+    error_exit "Streamlit is not installed. Run: ${DYNAWO_PYTHON_COMMAND} -m pip install -r $DYNAWO_CURVE_VISUALIZER_DIR/requirements.txt"
+  fi
+  resolved_paths=()
+  for f in "$@"; do
+    if [ ! -f "$f" ]; then
+      error_exit "File not found: $f"
+    fi
+    case "${f,,}" in
+      *.csv|*.bin|*.jobs) ;;
+      *) error_exit "Unsupported file type: $f (expected .csv, .bin or .jobs)" ;;
+    esac
+    resolved_paths+=("$("$DYNAWO_PYTHON_COMMAND" -c "import os; print(os.path.realpath('$f'))")")
+  done
+  ${DYNAWO_PYTHON_COMMAND} -m streamlit run "$DYNAWO_CURVE_VISUALIZER_DIR/app.py" --server.maxUploadSize 1024 -- "${resolved_paths[@]}" || return 1
 }
 
 dump_model() {
@@ -1990,6 +2011,10 @@ deploy_dynawo() {
   cp -r $DYNAWO_CURVES_TO_HTML_DIR/resources/* sbin/curvesToHtml/resources/
   cp -r $DYNAWO_CURVES_TO_HTML_DIR/csvToHtml/*.py sbin/curvesToHtml/csvToHtml/
   cp -r $DYNAWO_CURVES_TO_HTML_DIR/xmlToHtml/*.py sbin/curvesToHtml/xmlToHtml/
+  mkdir -p sbin/curve_visualizer
+  cp $DYNAWO_CURVE_VISUALIZER_DIR/*.py sbin/curve_visualizer/
+  cp $DYNAWO_CURVE_VISUALIZER_DIR/requirements.txt sbin/curve_visualizer/
+  cp $DYNAWO_CURVE_VISUALIZER_DIR/README.md sbin/curve_visualizer/
   mkdir -p sbin/nrt/nrt_diff
   cp -r $DYNAWO_NRT_DIFF_DIR/*.py sbin/nrt/nrt_diff
   cp -r $DYNAWO_NRT_DIR/nrt.py sbin/nrt/.
@@ -2142,6 +2167,7 @@ create_distrib() {
   zip -r -g -y $ZIP_FILE dynawo/dynawo.sh
   zip -r -g -y $ZIP_FILE dynawo/ddb/*.$DYNAWO_SHARED_LIBRARY_SUFFIX dynawo/ddb/*.desc.xml dynawo/ddb/*.extvar
   zip -r -g -y $ZIP_FILE dynawo/sbin/curvesToHtml
+  zip -r -g -y $ZIP_FILE dynawo/sbin/curve_visualizer
   zip -r -g -y $ZIP_FILE dynawo/sbin/xsl
   zip -r -g -y $ZIP_FILE dynawo/sbin/nrt
 
@@ -2499,6 +2525,10 @@ case $MODE in
 
   curves-reference-same-graph)
     curves_visu_reference_same_graph ${ARGS} || error_exit "Error with reference curves plot"
+    ;;
+
+  curves-app)
+    curves_visu_app ${ARGS} || error_exit "Error launching curves visualizer app"
     ;;
 
   deploy)


### PR DESCRIPTION
Introduces a minimal DYN::BinaryCurves writer that opens a file, emits a header with every y[] variable name, and appends (t, y) records on each Simulation::updateCurves call. Activated by setting the curves entry exportMode to "BINARY"; the stream is flushed and closed in terminate().

Move BinaryCurves to CRV API and register BINARY in JOBS XSD

Relocates the BinaryCurves streaming writer from Simulation/ to API/CRV/ under the curves:: namespace (renamed CRVBinaryCurves.*), alongside the existing CSV/XML exporters, and adds BINARY as a valid value of the CurvesExportMode enum in the JOBS XSD.

Round binary curves values through double2String

Route each time and variable value through DYN::double2String (then back to double via std::stod) before the little-endian encode so the binary output carries the same decimal precision as the CSV/XML exporters instead of the full IEEE 754 double precision.

add app.

Add binary_curves CLI and share load_bin with the Streamlit app

Extracts the .bin parser out of app.py into a new binary_curves.py companion module so the Streamlit app and the command line share the same reader. The module adds two sub-commands:

  names    dumps every variable name to a text file by reading only the
           header — cheap even on multi-gigabyte files.
  extract  streams the record section in fixed-size chunks (default
           64 MiB), selects columns matching one or more fnmatch (or
           --regex) patterns, and writes them to a CSV alongside the
           time column. Files larger than RAM are handled without
           loading them whole.

README updated with CLI and programmatic-use examples.

Bump default extract chunk size to 1 GiB

SSD-backed machines comfortably absorb a 1 GiB working set and benefit from larger reads and fewer streaming iterations.

Support model-only and variable-only curve declarations

Make the @model and @variable attributes of <curve> optional so users can write:

  <curve model="GeneratorId"/>      capture every variable of the submodel
  <curve variable="generator_PGen"/> capture that variable on every submodel
                                     that exposes it

A new Model::expandCurvesCollection() virtual (implemented by ModelMulti) replaces shortcut entries with the concrete (model, variable) pairs just before DYNSimulation resolves the curves. Fully-specified curves and factor/exportType attributes are preserved.

Also bump the Streamlit visualizer's default maxUploadSize to 1024 MiB and add a regression test for the relaxed XML parser.

Add -c/--contains substring filter to binary_curves extract

Adds a plain-substring selector alongside the existing fnmatch / regex patterns, so a quick "every variable mentioning generator" extract becomes:

    python binary_curves.py extract sim.bin -c generator

-c and -p are repeatable and OR-combined; --regex still applies only to -p. extract now requires at least one of the two and errors out otherwise.

Add curves-app subcommand to launch the Streamlit visualizer

curves-app file1.csv [file2.bin ...] starts the curve visualizer app preloaded with the given files and a 1 GiB upload limit, mirroring how curves opens the existing HTML viewer. The app gains a sys.argv preload path: file paths after `--` are read once (cached on path/mtime/size so streamlit reruns don't re-read multi-GB inputs) and merged with anything the user uploads via the file uploader.

curves-app: validate file extension and resolve .jobs paths

- Reject preload paths whose extension isn't .csv, .bin or .jobs both in the shell launcher and in the app's CLI preload, so a wrong file no longer falls through to the CSV parser and surfaces as a cryptic pandas tokenizer error.
- Add a .jobs resolver: when curves-app is given a .jobs file, the app parses every <outputs directory=...><curves exportMode="..."/> entry and preloads the corresponding curves.csv / curves.bin from disk.
- Harden CSV separator detection (csv.Sniffer + multi-line column-count fallback) and drop trailing all-NaN "Unnamed: N" columns produced by Dynawo's value;value;\n format. Both the upload and preload paths now share a single _parse_csv_bytes helper.

Surface preloaded file names + disambiguate duplicate basenames

When curves-app preloads files (CLI args or .jobs resolution), show a green banner listing each loaded label alongside its absolute path so the user can confirm which simulation outputs were picked up. Two files that share the same basename (e.g. multiple simulations all named curves.csv) get disambiguated by prefixing with their parent directory, falling back to the absolute path if a collision still exists.

Use <dyn:outputs directory> as the label for jobs-resolved curves

When a .jobs file contains multiple <dyn:job> elements (each with its own <dyn:outputs directory="..."/>), the resolver now walks them job by job and labels each curves output as "<directory>/curves.{csv,bin}" so the UI shows one entry per job instead of three identical "curves.csv" collisions.

For example GeneratorPTanPhi.jobs (three sub-jobs with directories outputsRunning, outputsOmega, outputsPVar) preloads as

  outputsRunning/curves.csv
  outputsOmega/curves.csv
  outputsPVar/curves.csv

The cross-source disambiguation already in place still kicks in if several .jobs files share the same outputs directory name.

jobs-with-curves: launch the Streamlit visualizer instead of HTML

Reuses curves_visu_app — the .jobs path is forwarded as-is; the app parses <dyn:outputs directory>/<dyn:curves exportMode> to load the right csv/bin file per job, with the outputs directory in the label so multi-job runs are easy to tell apart.

The old HTML pipeline (curvesToHtml.py) is still reachable via the standalone "curves" subcommand. install_jquery is no longer needed here because the app doesn't depend on jquery.

**Checklist before requesting a review**

*use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes*

- [ ] unit tests and non-regression tests were added (new model, new feature and bug fix)
- [ ] main documentation was updated (update of input/output file, 3rd party, model, repository organization, solver)
- [ ] example documentations were updated (new example in examples folder)
- [ ] the corresponding milestone was added in the ticket and in this PR
- [ ] if this PR requires to update dyd or par files of exisiting simulations: the corresponding python was added in util/xsl and platform DB were updated
- [ ] if this PR modifies a dictionary: the corresponding french dictionary was updated
